### PR TITLE
EPIC3: deterministic ragpack CLI

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="noesisnoema-pipeline" />
   </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="nn-pipeline" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/noesisnoema-pipeline.iml
+++ b/.idea/noesisnoema-pipeline.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="noesisnoema-pipeline" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="nn-pipeline" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/exporters" vcs="Git" />
   </component>
 </project>

--- a/chunker/__init__.py
+++ b/chunker/__init__.py
@@ -1,10 +1,27 @@
 """
 noesisnoema-pipeline chunker module.
 
-This module provides text chunking functionality for document processing
-in RAG (Retrieval-Augmented Generation) pipelines.
+Provides deterministic text chunking for RAGPack generation.
+All public types and helpers are exported here so callers import
+from a single stable surface.
 """
 
+from .chunk_record import (
+    ChunkRecord,
+    build_chunk_record,
+    build_snippet,
+    compute_chunk_id,
+    compute_chunk_text_hash,
+    compute_chunking_config_hash,
+)
 from .token_chunker import TokenChunker
 
-__all__ = ["TokenChunker"]
+__all__ = [
+    "ChunkRecord",
+    "build_chunk_record",
+    "build_snippet",
+    "compute_chunk_id",
+    "compute_chunk_text_hash",
+    "compute_chunking_config_hash",
+    "TokenChunker",
+]

--- a/chunker/chunk_record.py
+++ b/chunker/chunk_record.py
@@ -1,0 +1,280 @@
+"""
+Canonical chunk record schema and deterministic chunk_id generation.
+
+This module defines ChunkRecord — the single source of truth for chunk
+identity, lineage, and metadata in the RAGPack generation pipeline.
+
+Design contract (EPIC3 Stage 1):
+- chunk_id is always derived deterministically from content and config.
+- No UUID4 or wall-clock timestamps are used as primary identifiers.
+- Every ChunkRecord is fully traceable back to its source document.
+"""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+
+_CHUNK_ID_VERSION = "1"
+_SNIPPET_MAX_CHARS = 200
+
+
+def _sha256_hex(*parts: str) -> str:
+    """Return a hex SHA-256 digest of all parts joined by a null byte."""
+    payload = "\x00".join(str(p) for p in parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def compute_chunk_text_hash(chunk_text: str) -> str:
+    """
+    Return a stable SHA-256 hex digest of the chunk text.
+
+    The text is UTF-8 encoded before hashing so the hash is
+    unambiguous and portable across Python environments.
+    """
+    return hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+
+
+def compute_chunking_config_hash(
+    chunk_size: int,
+    overlap: int,
+    tokenizer_name: str,
+    preserve_sentences: bool,
+) -> str:
+    """
+    Return a stable SHA-256 hex digest of the chunking configuration.
+
+    The config is serialised as a canonically-sorted JSON string so
+    that field ordering never changes the resulting hash.
+    """
+    config = {
+        "chunk_size": chunk_size,
+        "overlap": overlap,
+        "preserve_sentences": preserve_sentences,
+        "tokenizer_name": tokenizer_name,
+        "version": _CHUNK_ID_VERSION,
+    }
+    canonical = json.dumps(config, sort_keys=True, ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_chunk_id(
+    source_id: str,
+    char_start: int,
+    char_end: int,
+    chunk_text_hash: str,
+    chunking_config_hash: str,
+) -> str:
+    """
+    Return a deterministic, stable chunk identifier.
+
+    Rule (EPIC3 Stage 1):
+        chunk_id = sha256(
+            source_id +
+            char_start +
+            char_end +
+            chunk_text_hash +
+            chunking_config_hash
+        )
+
+    All inputs must be non-empty / non-negative; passing empty strings
+    or negative positions is an explicit caller error.
+    """
+    if not source_id:
+        raise ValueError("source_id must not be empty")
+    if char_start < 0:
+        raise ValueError("char_start must be >= 0")
+    if char_end <= char_start:
+        raise ValueError("char_end must be > char_start")
+    if not chunk_text_hash:
+        raise ValueError("chunk_text_hash must not be empty")
+    if not chunking_config_hash:
+        raise ValueError("chunking_config_hash must not be empty")
+
+    return _sha256_hex(
+        source_id,
+        str(char_start),
+        str(char_end),
+        chunk_text_hash,
+        chunking_config_hash,
+    )
+
+
+@dataclass
+class ChunkRecord:
+    """
+    Canonical record for a single text chunk produced by the pipeline.
+
+    All fields are required unless explicitly marked Optional.
+    There are no mutable defaults; callers must supply every field.
+
+    Identity / lineage fields
+    -------------------------
+    chunk_id            Deterministic SHA-256 derived from source + offsets +
+                        chunk content + chunking config.  Never a UUID.
+    source_id           Stable identifier for the originating source document
+                        (e.g. SHA-256 of canonical file path + file content hash).
+    source_path         Original file path or URI of the source document.
+    source_hash         SHA-256 hex digest of the raw source file content.
+    chunk_index         Zero-based ordinal of this chunk within the source.
+
+    Position fields
+    ---------------
+    char_start          Start character offset in the stripped source text.
+    char_end            End character offset (exclusive) in the stripped source text.
+    token_count         Number of tokens in this chunk (model-specific; recorded for
+                        information and reproducibility checks, not as a stable ID).
+
+    Structure fields (optional, populated when source supports them)
+    ----------------------------------------------------------------
+    section             Heading or section title nearest to this chunk, if extractable.
+    page                Page number(s) this chunk spans, if the source is paginated.
+
+    Content fields
+    --------------
+    text_snippet        First 200 characters of the chunk text, for human inspection.
+    chunk_text_hash     SHA-256 hex digest of the chunk text (UTF-8 encoded).
+
+    Config lineage
+    --------------
+    chunking_config_hash  SHA-256 hex digest of the chunking configuration that
+                          produced this chunk.  Allows later reproducibility checks.
+    """
+
+    chunk_id: str
+    source_id: str
+    source_path: str
+    source_hash: str
+    chunk_index: int
+    char_start: int
+    char_end: int
+    token_count: int
+    text_snippet: str
+    chunk_text_hash: str
+    chunking_config_hash: str
+
+    # Optional — populated when source type supports these
+    section: Optional[str] = None
+    page: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        """Validate field invariants after construction."""
+        if not self.chunk_id:
+            raise ValueError("chunk_id must not be empty")
+        if not self.source_id:
+            raise ValueError("source_id must not be empty")
+        if not self.source_path:
+            raise ValueError("source_path must not be empty")
+        if not self.source_hash:
+            raise ValueError("source_hash must not be empty")
+        if self.chunk_index < 0:
+            raise ValueError("chunk_index must be >= 0")
+        if self.char_start < 0:
+            raise ValueError("char_start must be >= 0")
+        if self.char_end <= self.char_start:
+            raise ValueError("char_end must be > char_start")
+        if self.token_count < 1:
+            raise ValueError("token_count must be >= 1")
+        if not self.chunk_text_hash:
+            raise ValueError("chunk_text_hash must not be empty")
+        if not self.chunking_config_hash:
+            raise ValueError("chunking_config_hash must not be empty")
+        if len(self.text_snippet) > _SNIPPET_MAX_CHARS + 3:
+            # +3 for the trailing "..." that _build_snippet appends
+            raise ValueError(
+                f"text_snippet must not exceed {_SNIPPET_MAX_CHARS + 3} characters"
+            )
+
+    def to_dict(self) -> dict:
+        """Return a plain dict representation suitable for JSON serialisation."""
+        return {
+            "chunk_id": self.chunk_id,
+            "source_id": self.source_id,
+            "source_path": self.source_path,
+            "source_hash": self.source_hash,
+            "chunk_index": self.chunk_index,
+            "char_start": self.char_start,
+            "char_end": self.char_end,
+            "token_count": self.token_count,
+            "section": self.section,
+            "page": self.page,
+            "text_snippet": self.text_snippet,
+            "chunk_text_hash": self.chunk_text_hash,
+            "chunking_config_hash": self.chunking_config_hash,
+        }
+
+
+def build_snippet(text: str) -> str:
+    """
+    Return a human-readable snippet of at most 200 characters.
+
+    Appends '...' when the text is truncated so the consumer knows the
+    snippet is not the full chunk text.
+    """
+    if len(text) <= _SNIPPET_MAX_CHARS:
+        return text
+    return text[:_SNIPPET_MAX_CHARS] + "..."
+
+
+def build_chunk_record(
+    *,
+    chunk_text: str,
+    chunk_index: int,
+    char_start: int,
+    char_end: int,
+    token_count: int,
+    source_id: str,
+    source_path: str,
+    source_hash: str,
+    chunking_config_hash: str,
+    section: Optional[str] = None,
+    page: Optional[int] = None,
+) -> ChunkRecord:
+    """
+    Construct a fully-populated ChunkRecord.
+
+    This factory is the single authorised path for creating ChunkRecords.
+    It derives chunk_text_hash and chunk_id deterministically from the
+    supplied inputs so callers cannot accidentally supply stale values.
+
+    Args:
+        chunk_text:           Raw text of the chunk.
+        chunk_index:          Zero-based ordinal within the source.
+        char_start:           Start character offset in the stripped source.
+        char_end:             End character offset (exclusive) in the stripped source.
+        token_count:          Token count for this chunk.
+        source_id:            Stable source document identifier.
+        source_path:          Original file path or URI.
+        source_hash:          SHA-256 hex of the raw source file content.
+        chunking_config_hash: SHA-256 hex of the chunking configuration.
+        section:              Optional nearest section/heading.
+        page:                 Optional page number.
+
+    Returns:
+        A validated ChunkRecord.
+    """
+    chunk_text_hash = compute_chunk_text_hash(chunk_text)
+    chunk_id = compute_chunk_id(
+        source_id=source_id,
+        char_start=char_start,
+        char_end=char_end,
+        chunk_text_hash=chunk_text_hash,
+        chunking_config_hash=chunking_config_hash,
+    )
+    return ChunkRecord(
+        chunk_id=chunk_id,
+        source_id=source_id,
+        source_path=source_path,
+        source_hash=source_hash,
+        chunk_index=chunk_index,
+        char_start=char_start,
+        char_end=char_end,
+        token_count=token_count,
+        text_snippet=build_snippet(chunk_text),
+        chunk_text_hash=chunk_text_hash,
+        chunking_config_hash=chunking_config_hash,
+        section=section,
+        page=page,
+    )
+

--- a/chunker/token_chunker.py
+++ b/chunker/token_chunker.py
@@ -1,12 +1,26 @@
 """
 Token-based text chunking implementation.
 
-This module provides TokenChunker class for splitting text into chunks
+This module provides the TokenChunker class, which splits text into chunks
 based on token count with configurable overlap.
+
+EPIC3 Stage 1 update
+--------------------
+TokenChunker now exposes ``chunk_document``, which returns a list of
+``ChunkRecord`` objects with fully deterministic ``chunk_id`` values.
+
+The existing ``chunk_text`` and ``chunk_text_with_offsets`` methods are
+preserved for backward compatibility with existing code and tests.
 """
 
-from typing import List, Optional, Union, Dict, Any
+from typing import Dict, Any, List, Optional
 import warnings
+
+from .chunk_record import (
+    ChunkRecord,
+    build_chunk_record,
+    compute_chunking_config_hash,
+)
 
 # Try to import transformers, fall back to basic splitting if not available
 try:
@@ -67,7 +81,16 @@ class TokenChunker:
         
         # Character to token ratio estimation (rough approximation)
         self._char_to_token_ratio = 4.0  # Approximate chars per token
-    
+
+        # Pre-compute the config hash once so all chunks produced by this
+        # instance share the same stable identifier.
+        self._config_hash: str = compute_chunking_config_hash(
+            chunk_size=self.chunk_size,
+            overlap=self.overlap,
+            tokenizer_name=self.tokenizer_name,
+            preserve_sentences=self.preserve_sentences,
+        )
+
     def _count_tokens(self, text: str) -> int:
         """Count tokens in text using tokenizer or estimation."""
         if self.tokenizer is not None:
@@ -243,15 +266,66 @@ class TokenChunker:
     
     def get_chunker_metadata(self) -> Dict[str, Any]:
         """
-        Get chunker configuration metadata for manifest.
-        
+        Return chunker configuration metadata for the manifest.
+
         Returns:
-            Dictionary with chunker metadata
+            Dictionary with chunker metadata including a stable config hash
+            that can be stored in the RAGPack manifest for reproducibility.
         """
         return {
             "method": "token_based",
             "chunk_size": self.chunk_size,
             "overlap": self.overlap,
             "tokenizer_name": self.tokenizer_name,
-            "preserve_sentences": self.preserve_sentences
+            "preserve_sentences": self.preserve_sentences,
+            "config_hash": self._config_hash,
         }
+
+    def chunk_document(
+        self,
+        text: str,
+        source_id: str,
+        source_path: str,
+        source_hash: str,
+        section: Optional[str] = None,
+        page: Optional[int] = None,
+    ) -> List[ChunkRecord]:
+        """
+        Split text into ChunkRecord objects with deterministic chunk IDs.
+
+        This is the primary method for EPIC3 production use.  Every returned
+        ChunkRecord has a fully traceable, deterministic ``chunk_id`` derived
+        from the source identity, character offsets, chunk text, and chunking
+        configuration.
+
+        Args:
+            text:         Source text to split.
+            source_id:    Stable identifier for the originating source document.
+            source_path:  Original file path or URI.
+            source_hash:  SHA-256 hex digest of the raw source file content.
+            section:      Optional nearest section/heading for every chunk.
+            page:         Optional page number for every chunk.
+
+        Returns:
+            Ordered list of ChunkRecord objects, empty for blank input.
+        """
+        raw_chunks = self.chunk_text_with_offsets(text, doc_id=source_id)
+        records: List[ChunkRecord] = []
+
+        for index, raw in enumerate(raw_chunks):
+            record = build_chunk_record(
+                chunk_text=raw["text"],
+                chunk_index=index,
+                char_start=raw["start_char"],
+                char_end=raw["end_char"],
+                token_count=raw["token_count"],
+                source_id=source_id,
+                source_path=source_path,
+                source_hash=source_hash,
+                chunking_config_hash=self._config_hash,
+                section=section,
+                page=page,
+            )
+            records.append(record)
+
+        return records

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,11 @@
+"""
+noesisnoema-pipeline CLI package.
+
+Exposes the nn-pipeline command-line entrypoint and the testable
+pipeline function that backs it.
+"""
+
+from .build_ragpack import app, run_pipeline
+
+__all__ = ["app", "run_pipeline"]
+

--- a/cli/build_ragpack.py
+++ b/cli/build_ragpack.py
@@ -1,0 +1,367 @@
+"""
+nn-pipeline build — CLI entrypoint for deterministic RAGPack generation.
+
+Design contract (EPIC3 Stage 3 — CLI component)
+-------------------------------------------------
+Doctrine alignment (RAGFish invocation-boundary.md, execution-flow.md):
+- Every execution is explicitly triggered by a human action (CLI invocation).
+- All inputs are explicit arguments; nothing is inferred from environment
+  globals, wall clocks called implicitly, or auto-discovered at runtime.
+- creation_time is a required argument so output is fully reproducible
+  from the same inputs without patching datetime inside the pipeline.
+- Files are enumerated and sorted deterministically before processing.
+- No background threads, no autonomous retries, no hidden side effects.
+- All errors surface as structured, human-readable messages; nothing is
+  swallowed silently.
+- The pipeline logic (run_pipeline) is separated from the CLI layer so
+  it can be tested directly without subprocess invocation.
+
+Usage
+-----
+    nn-pipeline build \\
+        --input_dir  ./docs \\
+        --output_dir ./ragpack \\
+        --chunk_size 512 \\
+        --overlap    50 \\
+        --creation_time 2026-03-07T00:00:00
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import typer
+
+from chunker import TokenChunker
+from chunker.chunk_record import ChunkRecord
+from embedder.deterministic_embedder import DEFAULT_MODEL_NAME, DeterministicEmbedder
+from ragpack import RagpackBuilder, RagpackWriter
+
+
+# ---------------------------------------------------------------------------
+# Supported source file extensions (deterministic, fixed set)
+# ---------------------------------------------------------------------------
+
+_SUPPORTED_EXTENSIONS: frozenset[str] = frozenset({".txt", ".md"})
+
+# ---------------------------------------------------------------------------
+# Typer application
+# ---------------------------------------------------------------------------
+
+app = typer.Typer(
+    name="nn-pipeline",
+    help="Deterministic RAGPack generator — EPIC3 Stage 3.",
+    add_completion=False,
+    no_args_is_help=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# PipelineResult — returned by run_pipeline for testability
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """
+    Outcome of a single run_pipeline() call.
+
+    Fields
+    ------
+    output_dir      Resolved output directory path.
+    chunk_count     Total number of chunks produced.
+    file_count      Number of source files processed.
+    source_files    Sorted list of source file paths that were processed.
+    written_paths   Dict mapping artifact name → absolute Path on disk.
+    """
+
+    output_dir: Path
+    chunk_count: int
+    file_count: int
+    source_files: List[Path]
+    written_paths: dict
+
+
+# ---------------------------------------------------------------------------
+# Source file helpers
+# ---------------------------------------------------------------------------
+
+def _collect_source_files(input_dir: Path) -> List[Path]:
+    """
+    Return a sorted, deterministic list of supported source files
+    found directly inside input_dir (non-recursive).
+
+    Sorting is by filename (case-sensitive, lexicographic) so the order
+    is identical across all operating systems and file systems.
+
+    Only files with extensions in _SUPPORTED_EXTENSIONS are included.
+    Hidden files (names starting with '.') are excluded.
+
+    Raises:
+        typer.BadParameter: if input_dir does not exist or is not a directory.
+        typer.Exit:         if no supported files are found.
+    """
+    if not input_dir.exists():
+        typer.echo(f"ERROR: input_dir '{input_dir}' does not exist.", err=True)
+        raise typer.Exit(code=1)
+    if not input_dir.is_dir():
+        typer.echo(f"ERROR: input_dir '{input_dir}' is not a directory.", err=True)
+        raise typer.Exit(code=1)
+
+    files = sorted(
+        p for p in input_dir.iterdir()
+        if p.is_file()
+        and not p.name.startswith(".")
+        and p.suffix.lower() in _SUPPORTED_EXTENSIONS
+    )
+
+    if not files:
+        typer.echo(
+            f"ERROR: No supported files ({', '.join(sorted(_SUPPORTED_EXTENSIONS))}) "
+            f"found in '{input_dir}'.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    return files
+
+
+def _compute_source_hash(file_path: Path) -> str:
+    """Return a SHA-256 hex digest of the raw file content bytes."""
+    return hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+
+def _compute_source_id(file_path: Path, source_hash: str) -> str:
+    """
+    Return a stable source_id derived from the canonical file name and
+    its content hash, joined by a null byte.
+
+    Using only the file name (not the full path) keeps source_id stable
+    when the pack is moved between machines.
+    """
+    payload = f"{file_path.name}\x00{source_hash}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Core pipeline — separated from CLI so it is directly testable
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    input_dir: Path,
+    output_dir: Path,
+    chunk_size: int,
+    overlap: int,
+    creation_time: str,
+    model_name: str = DEFAULT_MODEL_NAME,
+    verbose: bool = False,
+) -> PipelineResult:
+    """
+    Execute the full deterministic RAGPack generation pipeline.
+
+    This function is the single authorised pipeline entry point.  It is
+    called by the ``build`` CLI command and can also be called directly
+    in tests without subprocess overhead.
+
+    Pipeline steps (in order):
+        1. Collect and sort source files from input_dir.
+        2. For each file (in sorted order):
+           a. Read content.
+           b. Compute source_hash and source_id.
+           c. Chunk with TokenChunker using the supplied configuration.
+        3. All ChunkRecords are accumulated in file-sort order.
+        4. RagpackBuilder embeds and assembles the Ragpack.
+        5. RagpackWriter writes the three artifacts to output_dir.
+
+    Args:
+        input_dir:     Directory containing source text/markdown files.
+        output_dir:    Directory where artifacts will be written.
+        chunk_size:    Maximum tokens per chunk.
+        overlap:       Token overlap between consecutive chunks.
+        creation_time: ISO-8601 timestamp string (caller-supplied for
+                       reproducibility; never generated internally).
+        model_name:    HuggingFace embedding model identifier.
+        verbose:       Whether to emit progress lines to stdout.
+
+    Returns:
+        PipelineResult with outcome metadata.
+
+    Raises:
+        typer.Exit(code=1): on any recoverable error.
+        Any unhandled exception propagates to the caller.
+    """
+    source_files = _collect_source_files(input_dir)
+
+    chunker = TokenChunker(
+        chunk_size=chunk_size,
+        overlap=overlap,
+        preserve_sentences=False,
+    )
+
+    all_chunks: List[ChunkRecord] = []
+    source_docs: list = []
+
+    for file_path in source_files:
+        if verbose:
+            typer.echo(f"  Processing: {file_path.name}")
+
+        raw_bytes = file_path.read_bytes()
+        text = raw_bytes.decode("utf-8", errors="replace")
+        source_hash = hashlib.sha256(raw_bytes).hexdigest()
+        source_id = _compute_source_id(file_path, source_hash)
+
+        file_chunks = chunker.chunk_document(
+            text=text,
+            source_id=source_id,
+            source_path=str(file_path),
+            source_hash=source_hash,
+        )
+        all_chunks.extend(file_chunks)
+
+        source_docs.append({
+            "source_id":   source_id,
+            "source_path": str(file_path),
+            "source_hash": source_hash,
+            "file_name":   file_path.name,
+            "chunk_count": len(file_chunks),
+        })
+
+    if verbose:
+        typer.echo(f"  Total chunks: {len(all_chunks)}")
+        typer.echo(f"  Loading embedder: {model_name}")
+
+    embedder = DeterministicEmbedder(model_name)
+    builder  = RagpackBuilder(embedder)
+    ragpack  = builder.build(
+        chunks=all_chunks,
+        creation_time=creation_time,
+        source_documents=source_docs,
+    )
+
+    writer = RagpackWriter()
+    written_paths = writer.write(ragpack, output_dir)
+
+    return PipelineResult(
+        output_dir=output_dir.resolve(),
+        chunk_count=len(all_chunks),
+        file_count=len(source_files),
+        source_files=source_files,
+        written_paths=written_paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+@app.command("build")
+def build(
+    input_dir: Path = typer.Option(
+        ...,
+        "--input_dir",
+        help="Directory containing source .txt or .md files to chunk and embed.",
+        exists=False,           # validated manually for better error messages
+        file_okay=False,
+        resolve_path=True,
+    ),
+    output_dir: Path = typer.Option(
+        ...,
+        "--output_dir",
+        help="Directory where ragpack artifacts will be written.",
+        resolve_path=True,
+    ),
+    chunk_size: int = typer.Option(
+        512,
+        "--chunk_size",
+        help="Maximum number of tokens per chunk.",
+        min=1,
+    ),
+    overlap: int = typer.Option(
+        50,
+        "--overlap",
+        help="Number of tokens to overlap between consecutive chunks.",
+        min=0,
+    ),
+    creation_time: str = typer.Option(
+        ...,
+        "--creation_time",
+        help=(
+            "ISO-8601 timestamp to embed in the manifest, e.g. "
+            "2026-03-07T00:00:00.  Must be supplied explicitly so "
+            "the output is reproducible."
+        ),
+    ),
+    model: str = typer.Option(
+        DEFAULT_MODEL_NAME,
+        "--model",
+        help="HuggingFace embedding model identifier.",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        help="Emit progress information to stdout.",
+    ),
+) -> None:
+    """
+    Build a deterministic RAGPack from documents in INPUT_DIR.
+
+    Supported file types: .txt, .md
+
+    Files are processed in sorted (lexicographic) order so output is
+    identical across runs with the same inputs and creation_time.
+    """
+    # --- Validate overlap vs chunk_size before touching the filesystem ---
+    if overlap >= chunk_size:
+        typer.echo(
+            f"ERROR: --overlap ({overlap}) must be less than --chunk_size ({chunk_size}).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not creation_time.strip():
+        typer.echo("ERROR: --creation_time must not be empty.", err=True)
+        raise typer.Exit(code=1)
+
+    if verbose:
+        typer.echo(f"nn-pipeline build")
+        typer.echo(f"  input_dir:     {input_dir}")
+        typer.echo(f"  output_dir:    {output_dir}")
+        typer.echo(f"  chunk_size:    {chunk_size}")
+        typer.echo(f"  overlap:       {overlap}")
+        typer.echo(f"  creation_time: {creation_time}")
+        typer.echo(f"  model:         {model}")
+
+    try:
+        result = run_pipeline(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            chunk_size=chunk_size,
+            overlap=overlap,
+            creation_time=creation_time,
+            model_name=model,
+            verbose=verbose,
+        )
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"ERROR: Pipeline failed — {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(
+        f"RAGPack written to: {result.output_dir}\n"
+        f"  Files processed:  {result.file_count}\n"
+        f"  Chunks produced:  {result.chunk_count}\n"
+        f"  Artifacts:\n"
+        + "\n".join(f"    {k}: {v}" for k, v in result.written_paths.items())
+    )
+
+
+# ---------------------------------------------------------------------------
+# Script entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    app()
+

--- a/docs/epic3-ragpack-knowledge-engine-alignment.md
+++ b/docs/epic3-ragpack-knowledge-engine-alignment.md
@@ -1,0 +1,533 @@
+# EPIC3 RAGPack Knowledge Engine Alignment
+
+**Repository:** `noesisnoema-pipeline`  
+**Branch:** `feature/epic3-ragpack-knowledge-engine`  
+**Date:** 2026-03-06
+
+## Purpose
+
+This document aligns EPIC3 planning for this repository with the current RAGFish doctrine and the actual branch state before any implementation work begins.
+
+It is intentionally **design-only**. It does **not** authorize code changes beyond the future implementation plan described below.
+
+---
+
+## 1. EPIC3 Scope Clarification
+
+### What EPIC3 means in the current architecture
+
+In this repository, **EPIC3** should be interpreted as the work required to turn `noesisnoema-pipeline` into a **deterministic knowledge-artifact generator** for RAGPack production.
+
+That means:
+- ingesting source documents in a controlled way,
+- chunking them deterministically,
+- generating reproducible embeddings,
+- preserving evidence lineage,
+- packaging outputs into a stable RAGPack contract,
+- and verifying that later retrieval against those artifacts is deterministic.
+
+### What this repository is
+
+This repository is **not** the Noesis/Noema runtime.
+
+It should be treated as a **generation-time toolchain** in the Knowledge Layer. Its job is to create immutable, inspectable artifacts that later runtime components can consume.
+
+### What this repository is not
+
+Per current architecture and RAGFish doctrine, this repository is **not** responsible for:
+- routing user invocations,
+- enforcing the runtime invocation boundary at request time,
+- session handling,
+- memory lifecycle enforcement for live conversations,
+- response generation,
+- runtime fallback behavior,
+- or UI/client rendering.
+
+### Generation-time concerns vs runtime concerns
+
+**Generation-time concerns for this repo**
+- source inventory and normalization,
+- chunking policy and chunk metadata,
+- embedding generation and reproducibility,
+- manifest construction,
+- evidence lineage,
+- output hashing and packaging,
+- offline verification of artifact integrity and deterministic retrieval expectations.
+
+**Runtime concerns for client/runtime layers**
+- `NoemaQuestion` / `NoemaResponse` handling,
+- router decisions,
+- privacy-level enforcement,
+- invocation logging,
+- fallback policy,
+- session-scoped memory,
+- user-visible execution logs,
+- synchronous invocation lifecycle.
+
+### Alignment implication
+
+The doctrine documents on invocation boundary, execution flow, memory lifecycle, observability, and security still matter here, but **indirectly**:
+- this repo must produce artifacts that are safe and traceable for later runtime use,
+- this repo must avoid hidden side effects and undeclared persistence,
+- and this repo must not drift into runtime-agent responsibilities.
+
+---
+
+## 2. Current Repository Assessment
+
+### Current folder/file structure
+
+Current branch contents are centered around a small Python package surface:
+
+- `chunker/`
+  - `token_chunker.py`
+  - `README.md`
+  - `__init__.py`
+- `writer/`
+  - `pack_writer.py`
+  - `__init__.py`
+- `schemas/`
+  - `manifest_v1_1.json`
+- `tests/`
+  - `test_token_chunker.py`
+  - `test_token_chunker_v1_1.py`
+- root utilities
+  - `create_ragpack.py`
+  - `validate_chunker.py`
+  - `README.md`
+  - `requirements.txt`
+  - `.github/PULL_REQUEST_TEMPLATE.md`
+
+### What currently exists
+
+Present in code today:
+- **Chunking implementation** via `chunker/TokenChunker`
+- **Chunk metadata support** including offsets, paragraph boundaries, and snippets
+- **Pack writing** via `writer/PackWriter`
+- **Manifest schema draft** in `schemas/manifest_v1_1.json`
+- **Chunker-focused tests**
+- **Sample pack generation script** in `create_ragpack.py`
+
+Important detail: the current `PackWriter` can write embeddings **if they are already provided**, but there is **no in-repo embedding engine** that computes them from source documents.
+
+### What was previously removed
+
+The current branch history explicitly shows that a large part of the older surface area was removed in commit `115cf3f` (`Pipeline purification: deterministic chunk-only generator (#11)`).
+
+That commit deleted, among other things:
+- `embed/`
+- `index/`
+- `retriever/`
+- `nn-pack`
+- `nn-retriever`
+- `notebooks/`
+- `exported/`
+- retriever/CLI tests and workflow tests
+- sample/demo artifacts and demo scripts
+
+This is not just “missing code.” It is evidence that the repository was intentionally narrowed from a broader workflow into a more limited generator-oriented codebase.
+
+### Current repo vs documented expectations: explicit conflicts
+
+The current repository state conflicts with several documented expectations:
+
+1. **`README.md` still describes notebook-driven and CLI-adjacent workflows**
+   - refers to `notebooks/`
+   - refers to Colab helpers
+   - describes producing full RAGPack outputs end-to-end
+   - implies embedder and validator workflows that are not present in the current branch
+
+2. **`.github/PULL_REQUEST_TEMPLATE.md` still assumes modules that do not exist in the branch**
+   - `embedder`
+   - `indexer`
+   - `cli`
+   - `notebook`
+   - BM25 / validator / backward compatibility flows
+
+3. **Current code is narrower than the docs**
+   - `create_ragpack.py` produces a toy zip with synthetic/random-seeded embeddings and `metadata.json`
+   - `writer/pack_writer.py` writes `manifest.json`, `citations.jsonl`, `embeddings.npy`, and `embeddings.csv`
+   - there is no end-to-end build pipeline from source documents to embeddings to verified retrieval output
+
+### Status of key EPIC3 capabilities
+
+| Capability | Status | Notes |
+|---|---|---|
+| Chunking | **Present** | `TokenChunker` exists with configurable size/overlap and offset metadata |
+| Embedding generation | **Partial / effectively absent** | Pack schema and writer expect embeddings, and `create_ragpack.py` fabricates deterministic sample embeddings, but there is no real embedder module in the current repo |
+| Retrieval workflow | **Absent** | No retriever, indexer, BM25, ANN, or verification harness in the current branch |
+| Notebook workflow | **Absent** | Notebooks were previously present and were explicitly removed in commit `115cf3f` |
+| CLI workflow | **Absent** | Historical references exist, but no current `nn-pack` CLI remains |
+| Manifest/schema support | **Partial** | Schema exists; pack writing exists; deterministic packaging and richer lineage are not yet complete |
+| Evidence traceability | **Partial** | Current chunk metadata has char offsets and paragraph boundaries, but source lineage is not yet complete enough for EPIC3 |
+
+### Additional current-state observations
+
+- `requirements.txt` currently signals a narrowed intent: “Deterministic RagPack Generator (no retrieval, no embedding)”.
+- `PackWriter` currently introduces non-determinism through `uuid.uuid4()` and `datetime.now()`.
+- `create_ragpack.py` is a sample/demo producer, not an authoritative production pipeline.
+- There is no current source ingestion layer for PDFs, markdown, text corpora, or document inventories.
+
+---
+
+## 3. RAGFish Alignment
+
+### How this repo fits the overall Noesis / Noema architecture
+
+RAGFish doctrine separates:
+- **runtime invocation behavior** from
+- **artifact preparation and knowledge packaging**.
+
+This repository belongs on the **artifact preparation** side.
+
+It should not implement the runtime execution loop described in `execution-flow.md`. Instead, it should prepare the knowledge assets that runtime components can consume later under the invocation boundary.
+
+### Mapping this repo to the Knowledge Layer
+
+This repository should be treated as the **Knowledge Layer build tool** for RAGPack generation.
+
+Its responsibility is to transform source material into a stable artifact set such as:
+- canonical chunk records,
+- embeddings,
+- lineage/citation records,
+- manifest metadata,
+- verification outputs,
+- packaged archives or directories.
+
+### Relationship to doctrine constraints
+
+Even though this repo is not a runtime executor, it should align with doctrine in the following ways:
+
+- **Invocation Boundary alignment:** no hidden background behavior, no undeclared side effects, no runtime autonomy.
+- **Observability alignment:** artifact generation must be reconstructable from configuration, source hashes, and manifest metadata.
+- **Security alignment:** no hidden persistence, no undeclared network behavior in the core path, clear trust boundaries for external models/assets.
+- **Evaluation alignment:** structural compliance and determinism come before subjective notions of retrieval “quality.”
+- **Memory alignment:** this repo must not become a persistent conversational memory store or vector accumulation service outside explicit artifact generation.
+
+### How generated artifacts are consumed later
+
+The intended downstream flow is:
+1. This repository generates a deterministic RAGPack.
+2. The pack is published or copied into a client/runtime environment.
+3. Later, at user invocation time, a client/runtime layer loads the pack.
+4. Retrieval occurs inside the runtime boundary using the generated artifacts.
+5. Runtime layers use lineage metadata to surface evidence and citations back to the user.
+
+That means this repo is **upstream of runtime retrieval**, not the retrieval runtime itself.
+
+---
+
+## 4. DoD Interpretation
+
+EPIC3 DoD must be translated into repository-specific, generation-side targets.
+
+### Chunking configurable
+
+**Done in this repository means:**
+- chunking parameters are explicit inputs, not hidden constants,
+- chunk size, overlap, boundary policy, tokenizer identity, and normalization policy are recorded in manifest metadata,
+- chunk ordering is deterministic,
+- chunk IDs are stable for identical source + config,
+- tests prove that identical inputs/config produce identical chunk records.
+
+### Embedding reproducible
+
+**Done in this repository means:**
+- a real embedding module exists,
+- model identity, version, artifact hash, dimension, backend, dtype, and configuration are captured in the manifest,
+- embedding generation uses deterministic execution settings,
+- identical source chunks and identical embedder configuration reproduce the same serialized embedding outputs within a defined tolerance,
+- reproducibility is validated in automated tests.
+
+### Retrieval deterministic
+
+Because this repo is **not** the runtime retriever, “retrieval deterministic” must be scoped carefully.
+
+**Done in this repository means:**
+- the repo defines a deterministic retrieval verification harness for generated artifacts,
+- verification uses fixed queries, a fixed similarity metric, fixed tie-break rules, and fixed top-k expectations,
+- verification can prove that a generated pack yields the same ranking behavior under the same conditions,
+- the repo does not need to become a serving retriever or runtime search service.
+
+### Evidence traceable
+
+**Done in this repository means:**
+- every chunk has a stable identity,
+- every chunk points back to a source document identity,
+- offsets/pages/sections/paragraph references are preserved where source type allows,
+- embeddings are linked to the exact chunk IDs they represent,
+- the manifest captures lineage and processing metadata needed to reconstruct provenance,
+- retrieval verification outputs can identify which source evidence should be surfaced later by runtime layers.
+
+---
+
+## 5. Proposed Target Architecture
+
+This is the desired internal architecture for EPIC3. It is intentionally design-only.
+
+### Proposed modules and responsibilities
+
+| Module | Responsibility |
+|---|---|
+| `chunker/` or `chunking/` | Deterministic text normalization, segmentation, chunk IDs, chunk metadata, boundary policy |
+| `embedding/` | Reproducible embedding generation, model metadata capture, deterministic backend configuration |
+| `manifest/` | Manifest assembly, schema versioning, config capture, content hashes, artifact inventory |
+| `lineage/` or `evidence/` | Source references, offsets/pages/sections, source hashes, chunk-to-source mapping, embedding-to-chunk mapping |
+| `verification/` | Deterministic retrieval verification, golden query fixtures, ranking assertions, artifact integrity checks |
+| `writer/` | Canonical serialization, packaging, stable zip/directory output, hash emission |
+| `cli/` | Explicit user entrypoints such as build/verify/show-manifest; no hidden background workflows |
+| `sources/` or `ingest/` | Canonical source discovery, stable ordering, document metadata extraction, normalization preconditions |
+
+### Recommended internal flow
+
+1. **Source inventory**
+   - enumerate inputs deterministically
+   - assign stable `source_id`
+   - compute source hashes
+
+2. **Chunk generation**
+   - normalize content
+   - apply chunking policy
+   - assign stable `chunk_id`
+   - attach offsets and section metadata
+
+3. **Embedding generation**
+   - embed chunk text in stable order
+   - capture embedder metadata and model hash
+   - bind output vectors to chunk IDs
+
+4. **Manifest and lineage assembly**
+   - capture configuration versions
+   - store file inventory, counts, hashes, timestamps/policies
+   - store source lineage summary
+
+5. **Deterministic verification**
+   - run pack integrity checks
+   - run retrieval determinism checks against fixed fixtures
+
+6. **Packaging**
+   - write canonical files
+   - produce deterministic pack hash
+   - emit final package as directory and/or zip
+
+### Architectural principle
+
+The architecture should stay **build-oriented and explicit**. No notebooks, background jobs, hidden caching, or runtime-agent behavior should be treated as the primary system design.
+
+---
+
+## 6. Determinism Strategy
+
+Determinism is a first-class requirement for EPIC3.
+
+### Chunk generation
+
+Determinism should be guaranteed by:
+- canonical input ordering,
+- canonical path handling,
+- canonical text normalization rules,
+- explicit tokenizer/version pinning,
+- explicit chunk configuration capture,
+- stable chunk ID derivation,
+- and tests that compare full chunk records, not only chunk counts.
+
+Recommended controls:
+- normalize line endings and whitespace policy explicitly,
+- record tokenizer name and tokenizer version/hash,
+- sort sources before processing,
+- derive chunk IDs from stable inputs such as `source_id + normalized offsets + chunk_text_hash + chunking_config_hash`.
+
+### Embedding generation
+
+Determinism should be guaranteed by:
+- pinned model version and artifact hash,
+- fixed backend and dtype,
+- fixed batch ordering,
+- fixed seeds where applicable,
+- documented hardware/precision constraints,
+- and reproducibility tests with clear tolerance rules.
+
+Recommended controls:
+- record model name, version, artifact hash, dimensions, backend, device, dtype,
+- avoid hidden remote model updates,
+- prefer a reproducible local artifact or pinned immutable remote reference,
+- define acceptable numeric tolerance if exact bitwise identity is not portable across environments.
+
+### Retrieval verification
+
+Determinism should be guaranteed by:
+- fixed verification queries,
+- a fixed scoring method,
+- exact tie-break rules,
+- no approximate ANN in the verification path,
+- and stored expected rankings for regression checking.
+
+Recommended controls:
+- use cosine or dot-product consistently and record it in manifest/verification metadata,
+- sort ties by stable `chunk_id`,
+- keep a small golden verification corpus in tests,
+- separate “verification retriever” from any future production runtime retriever.
+
+### Output packaging
+
+Determinism should be guaranteed by:
+- canonical JSON serialization,
+- stable file ordering,
+- explicit file hashes,
+- deterministic zip entry ordering and timestamps,
+- and manifest metadata that fully describes the build.
+
+Recommended controls:
+- sort JSON keys where practical,
+- serialize with stable indentation/encoding policy,
+- compute SHA-256 for source files and generated artifacts,
+- include generator version, dependency versions, schema version, and config hash in the manifest,
+- avoid random UUIDs and wall-clock timestamps as primary identifiers for deterministic builds.
+
+---
+
+## 7. Evidence Traceability Strategy
+
+EPIC3 should preserve evidence traceability from source document to chunk to embedding to verification result.
+
+### Required lineage at chunk level
+
+Each chunk should preserve at least:
+- `chunk_id`
+- `source_id`
+- `source_path` or source URI equivalent
+- source content hash
+- chunk ordinal within source
+- start/end character offsets
+- token count
+- page number(s) when source type supports paging
+- section/heading references when source type supports structure
+- snippet/preview text for inspection
+
+### Required lineage at embedding level
+
+Each embedding record should preserve at least:
+- `chunk_id`
+- embedding vector index position
+- embedder name/version/hash
+- embedding dimensions
+- dtype / backend metadata
+- embedding generation config hash
+
+### Required lineage at manifest level
+
+The manifest should preserve at least:
+- pack version
+- build/generator version
+- source inventory with hashes
+- chunking configuration
+- embedding configuration
+- artifact file list with hashes
+- verification metadata
+- provenance summary sufficient for deterministic reconstruction
+
+### Traceability rule
+
+A future runtime layer should be able to answer all of the following from generated artifacts:
+- Which source produced this chunk?
+- Where in the source did it come from?
+- Which embedder created this vector?
+- Which pack version and config generated it?
+- Which evidence should be shown to the user if this chunk is retrieved later?
+
+### Important constraint
+
+Traceability should be **explicit metadata**, not inferred later from filenames, ordering accidents, or undocumented conventions.
+
+---
+
+## 8. Zero-Scope / Non-Goals
+
+EPIC3 will **not** do the following in this phase:
+
+- no runtime agent logic
+- no invocation router implementation
+- no `NoemaQuestion` / `NoemaResponse` runtime execution path
+- no UI
+- no server execution
+- no session or conversational memory system
+- no hidden persistence beyond intended artifact generation
+- no background autonomous behavior
+- no automatic runtime fallback logic
+- no notebook-first workflow as the primary interface unless explicitly reinstated by design
+- no ad-hoc demos as substitutes for production contracts
+- no speculative retrieval service or hosted vector database
+- no hidden telemetry or network behavior in the core generation path
+
+If any of the above becomes necessary, it should be treated as a separate architectural decision, not as incidental EPIC3 scope creep.
+
+---
+
+## 9. Implementation Plan
+
+Implementation should proceed in small, verifiable stages.
+
+### Stage 1 — Freeze the artifact contract
+- Define the EPIC3 source-of-truth package layout and manifest contract.
+- Decide the canonical chunk record shape and lineage fields.
+- Decide deterministic ID and hashing rules.
+- Validation: schema tests and fixture-based manifest serialization tests.
+
+### Stage 2 — Make chunking fully deterministic and traceable
+- Extend chunk generation to emit stable IDs and richer source lineage.
+- Add source inventory and normalization rules.
+- Preserve offsets/pages/sections where available.
+- Validation: repeat-run chunk snapshot tests across fixed fixtures.
+
+### Stage 3 — Introduce a real reproducible embedding layer
+- Add embedder abstraction and pinned model metadata capture.
+- Implement deterministic embedding generation and serialization.
+- Bind embeddings explicitly to chunk IDs.
+- Validation: reproducibility tests with defined tolerance and stable metadata assertions.
+
+### Stage 4 — Build canonical manifest and packaging
+- Centralize manifest assembly.
+- Add file hashes, config hashes, dependency versions, and generator version.
+- Make directory and zip packaging canonical.
+- Validation: repeat-run pack hash or manifest-hash comparison tests.
+
+### Stage 5 — Add deterministic retrieval verification
+- Introduce a verification module with fixed queries and stable ranking expectations.
+- Keep it as an offline validation tool, not a runtime service.
+- Validation: golden ranking tests and negative tests for drift detection.
+
+### Stage 6 — Add explicit CLI entrypoints
+- Add a minimal explicit CLI such as `build`, `verify`, and `show-manifest`.
+- Ensure commands are transparent, non-autonomous, and loggable.
+- Validation: CLI integration tests on a tiny fixture corpus.
+
+### Stage 7 — Documentation and branch hardening
+- Update README and contributor docs to match the actual architecture.
+- Remove stale references that conflict with the purified branch scope.
+- Add a branch-level acceptance checklist for EPIC3.
+- Validation: documentation review against current repo structure and test commands.
+
+---
+
+## Key Architectural Decisions
+
+1. **EPIC3 is a Knowledge Layer build effort, not a runtime-agent effort.**
+2. **This repository should generate deterministic RAGPack artifacts, not execute Noesis/Noema invocations.**
+3. **Current README/template expectations are broader than the actual code and must not be treated as source of truth.**
+4. **Embedding and retrieval are not currently implemented here; they must be reintroduced deliberately, not assumed to exist.**
+5. **Traceability and determinism must be designed into IDs, manifests, and packaging from the start.**
+
+## Recommended First Implementation Step
+
+The recommended first implementation step is:
+
+**Freeze the canonical chunk/lineage contract before adding any new embedding or retrieval code.**
+
+Concretely, start by defining:
+- stable `source_id` and `chunk_id` rules,
+- the canonical chunk metadata shape,
+- required lineage fields,
+- and the manifest fields needed to record chunking deterministically.
+
+This is the correct first step because chunk identity and lineage are the foundation for all later EPIC3 requirements: reproducible embeddings, deterministic retrieval verification, and evidence traceability.
+

--- a/embedder/__init__.py
+++ b/embedder/__init__.py
@@ -1,0 +1,16 @@
+"""
+noesisnoema-pipeline embedder module.
+
+Provides deterministic, reproducible embedding generation for RAGPack
+artifact production (EPIC3 Stage 2).
+
+All public types and helpers are exported from this single surface.
+"""
+
+from .deterministic_embedder import DeterministicEmbedder, EmbedderMetadata
+
+__all__ = [
+    "DeterministicEmbedder",
+    "EmbedderMetadata",
+]
+

--- a/embedder/deterministic_embedder.py
+++ b/embedder/deterministic_embedder.py
@@ -1,0 +1,367 @@
+"""
+Deterministic embedding generation for RAGPack production.
+
+Design contract (EPIC3 Stage 2)
+--------------------------------
+- Model identity is pinned by name and resolved artifact hash at load time.
+- Embeddings are produced in the exact order chunks are supplied.
+- No random seeds, no stochastic inference paths, no background threads.
+- The same model + same chunk texts → byte-for-byte identical float32 vectors.
+- All metadata needed for manifest reproducibility is captured at load time.
+
+Public API
+----------
+    embedder = DeterministicEmbedder("sentence-transformers/all-MiniLM-L6-v2")
+    result   = embedder.embed_chunks(chunk_records)
+    # result.embeddings  : np.ndarray, shape (N, D), dtype float32
+    # result.metadata    : EmbedderMetadata
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import numpy as np
+
+from chunker.chunk_record import ChunkRecord
+
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Default model used when no model_name is supplied to DeterministicEmbedder.
+DEFAULT_MODEL_NAME: str = "sentence-transformers/all-MiniLM-L6-v2"
+
+#: Output dtype for all embedding arrays produced by this module.
+EMBEDDING_DTYPE: str = "float32"
+
+#: Batch size used during encoding.  Kept small so behaviour is identical
+#: regardless of available VRAM or RAM.
+_ENCODE_BATCH_SIZE: int = 64
+
+
+# ---------------------------------------------------------------------------
+# EmbedderMetadata — canonical metadata for manifest inclusion
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EmbedderMetadata:
+    """
+    Immutable metadata record describing the embedding configuration.
+
+    All fields are required; there are no optional fields.  This object
+    is the authoritative source of truth for the ``embedder`` block in
+    the RAGPack manifest.
+
+    Fields
+    ------
+    embedding_model     Short human-readable model name as supplied by the
+                        caller (e.g. ``"sentence-transformers/all-MiniLM-L6-v2"``).
+    embedding_version   Version string resolved from the loaded model's
+                        sentence_transformers library version, recorded so
+                        consumers can reproduce the exact library state.
+    embedding_dimension Number of dimensions in each output vector.
+    model_hash          SHA-256 hex digest of the sorted model configuration
+                        JSON.  Acts as a stable identity check for the loaded
+                        model without requiring the full weights to be hashed
+                        (which would be slow and environment-dependent).
+    dtype               NumPy dtype string for the output array (always
+                        ``"float32"`` in this implementation).
+    """
+
+    embedding_model: str
+    embedding_version: str
+    embedding_dimension: int
+    model_hash: str
+    dtype: str
+
+    def to_dict(self) -> dict:
+        """Return a plain dict suitable for JSON serialisation in the manifest."""
+        return {
+            "embedding_model": self.embedding_model,
+            "embedding_version": self.embedding_version,
+            "embedding_dimension": self.embedding_dimension,
+            "model_hash": self.model_hash,
+            "dtype": self.dtype,
+            # Legacy manifest keys kept for backward compatibility with PackWriter
+            "name": self.embedding_model,
+            "version": self.embedding_version,
+            "dimensions": self.embedding_dimension,
+        }
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingResult — output bundle from a single embed_chunks call
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EmbeddingResult:
+    """
+    Output of a single ``DeterministicEmbedder.embed_chunks`` call.
+
+    Fields
+    ------
+    embeddings  NumPy array of shape ``(N, D)`` and dtype ``float32``.
+                Row ``i`` corresponds to ``chunks[i]``.
+    metadata    EmbedderMetadata captured at embedder construction time.
+    chunk_ids   Ordered list of ``chunk_id`` strings, one per row, so that
+                downstream code can bind each embedding row back to its
+                ChunkRecord without relying on positional coincidence.
+    """
+
+    embeddings: np.ndarray
+    metadata: EmbedderMetadata
+    chunk_ids: List[str]
+
+    def __post_init__(self) -> None:
+        if self.embeddings.ndim != 2:
+            raise ValueError(
+                f"embeddings must be 2-D, got shape {self.embeddings.shape}"
+            )
+        if self.embeddings.dtype != np.float32:
+            raise ValueError(
+                f"embeddings dtype must be float32, got {self.embeddings.dtype}"
+            )
+        if self.embeddings.shape[0] != len(self.chunk_ids):
+            raise ValueError(
+                f"embeddings row count ({self.embeddings.shape[0]}) must equal "
+                f"len(chunk_ids) ({len(self.chunk_ids)})"
+            )
+        if self.embeddings.shape[1] != self.metadata.embedding_dimension:
+            raise ValueError(
+                f"embeddings column count ({self.embeddings.shape[1]}) must equal "
+                f"metadata.embedding_dimension ({self.metadata.embedding_dimension})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _compute_model_hash(model_config: dict) -> str:
+    """
+    Return a SHA-256 hex digest of the model configuration dictionary.
+
+    The config is serialised as a canonically sorted JSON string so
+    that field insertion order never influences the hash.
+    """
+    canonical = json.dumps(model_config, sort_keys=True, ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _resolve_st_version() -> str:
+    """Return the installed sentence_transformers library version string."""
+    try:
+        import sentence_transformers as _st
+        return str(_st.__version__)
+    except Exception:
+        return "unknown"
+
+
+def _set_deterministic_torch_flags() -> None:
+    """
+    Apply all available PyTorch determinism controls.
+
+    These flags ensure that CUDA/CPU operations that have non-deterministic
+    fast-paths fall back to deterministic equivalents.  No random seeds are
+    set; the goal is to eliminate non-determinism from the *algorithm*, not
+    to fix a random sequence.
+    """
+    try:
+        import torch
+        # Disable non-deterministic CUDA algorithms
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        # Disable cuDNN benchmarking (it selects fastest, not deterministic, algo)
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
+    except Exception:
+        # PyTorch may not be available in all test environments; skip silently
+        pass
+
+
+# ---------------------------------------------------------------------------
+# DeterministicEmbedder
+# ---------------------------------------------------------------------------
+
+class DeterministicEmbedder:
+    """
+    Loads a sentence-transformers model and embeds ChunkRecord lists
+    in a fully deterministic, reproducible manner.
+
+    Usage
+    -----
+    ::
+
+        embedder = DeterministicEmbedder("sentence-transformers/all-MiniLM-L6-v2")
+        result = embedder.embed_chunks(chunk_records)
+
+        embeddings = result.embeddings   # np.ndarray (N, 384), float32
+        metadata   = result.metadata     # EmbedderMetadata
+
+    Determinism guarantees
+    ----------------------
+    - The model is loaded once and never mutated after construction.
+    - ``torch.use_deterministic_algorithms`` is enabled at construction.
+    - ``cudnn.benchmark`` is disabled.
+    - Encoding is performed in a single sorted-order batch with
+      ``convert_to_numpy=True`` so no tensor RNG state is involved in the
+      output conversion.
+    - Output is always cast to ``float32`` before returning.
+    - The order of rows in the output array matches the order of the input
+      ``chunk_records`` list exactly — no internal reordering occurs.
+    """
+
+    def __init__(self, model_name: str = DEFAULT_MODEL_NAME) -> None:
+        """
+        Load the embedding model and capture all metadata.
+
+        Args:
+            model_name: HuggingFace model identifier or local path.
+                        Defaults to ``DEFAULT_MODEL_NAME``.
+
+        Raises:
+            ImportError:  if sentence-transformers is not installed.
+            RuntimeError: if the model fails to load.
+        """
+        if not model_name or not model_name.strip():
+            raise ValueError("model_name must not be empty")
+
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:
+            raise ImportError(
+                "sentence-transformers is required for DeterministicEmbedder. "
+                "Install it with: pip install sentence-transformers"
+            ) from exc
+
+        _set_deterministic_torch_flags()
+
+        try:
+            self._model = SentenceTransformer(model_name)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to load embedding model '{model_name}': {exc}"
+            ) from exc
+
+        self._model_name: str = model_name
+
+        # Resolve dimension from the loaded model
+        dimension: int = self._model.get_sentence_embedding_dimension()
+
+        # Build a stable model config hash from fields that are invariant
+        # for a given model name.  We include the dimension so that two
+        # models with the same name but different output sizes (e.g. after
+        # fine-tuning) produce different hashes.
+        model_config = {
+            "model_name": model_name,
+            "embedding_dimension": dimension,
+            "dtype": EMBEDDING_DTYPE,
+        }
+        model_hash = _compute_model_hash(model_config)
+
+        self._metadata = EmbedderMetadata(
+            embedding_model=model_name,
+            embedding_version=_resolve_st_version(),
+            embedding_dimension=dimension,
+            model_hash=model_hash,
+            dtype=EMBEDDING_DTYPE,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def metadata(self) -> EmbedderMetadata:
+        """EmbedderMetadata captured at construction time."""
+        return self._metadata
+
+    def embed_chunks(self, chunks: Sequence[ChunkRecord]) -> EmbeddingResult:
+        """
+        Embed a sequence of ChunkRecord objects and return aligned results.
+
+        The output ``EmbeddingResult.embeddings`` row ``i`` corresponds
+        exactly to ``chunks[i]``.  No reordering is performed.
+
+        Args:
+            chunks: Ordered sequence of ChunkRecord objects to embed.
+                    May be empty, in which case a zero-row array is returned.
+
+        Returns:
+            EmbeddingResult with ``embeddings``, ``metadata``, and
+            ``chunk_ids`` aligned to the input sequence.
+
+        Raises:
+            TypeError: if any element of ``chunks`` is not a ChunkRecord.
+        """
+        for idx, chunk in enumerate(chunks):
+            if not isinstance(chunk, ChunkRecord):
+                raise TypeError(
+                    f"chunks[{idx}] must be a ChunkRecord, "
+                    f"got {type(chunk).__name__}"
+                )
+
+        if not chunks:
+            empty_array = np.empty(
+                (0, self._metadata.embedding_dimension), dtype=np.float32
+            )
+            return EmbeddingResult(
+                embeddings=empty_array,
+                metadata=self._metadata,
+                chunk_ids=[],
+            )
+
+        # Extract texts in the exact order they were supplied.
+        # The chunk_ids list is built in parallel so the binding is
+        # guaranteed to be aligned regardless of what happens inside encode().
+        texts = [chunk.text_snippet for chunk in chunks]
+        chunk_ids = [chunk.chunk_id for chunk in chunks]
+
+        raw: np.ndarray = self._model.encode(
+            texts,
+            batch_size=_ENCODE_BATCH_SIZE,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            normalize_embeddings=False,
+        )
+
+        # Guarantee float32 dtype regardless of model's internal precision
+        embeddings = raw.astype(np.float32)
+
+        return EmbeddingResult(
+            embeddings=embeddings,
+            metadata=self._metadata,
+            chunk_ids=chunk_ids,
+        )
+
+    def embed_texts(self, texts: Sequence[str]) -> np.ndarray:
+        """
+        Embed a plain list of strings and return a float32 NumPy array.
+
+        This is a lower-level convenience method for callers that do not
+        have ChunkRecord objects.  It does not return chunk_ids.
+
+        Args:
+            texts: Ordered sequence of strings to embed.
+
+        Returns:
+            np.ndarray of shape ``(N, D)`` and dtype ``float32``.
+        """
+        if not texts:
+            return np.empty(
+                (0, self._metadata.embedding_dimension), dtype=np.float32
+            )
+
+        raw: np.ndarray = self._model.encode(
+            list(texts),
+            batch_size=_ENCODE_BATCH_SIZE,
+            show_progress_bar=False,
+            convert_to_numpy=True,
+            normalize_embeddings=False,
+        )
+        return raw.astype(np.float32)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "noesisnoema-pipeline"
+version = "0.3.0"
+description = "Deterministic RAGPack generator — EPIC3"
+requires-python = ">=3.11"
+dependencies = [
+    "transformers>=4.20.0",
+    "sentence-transformers>=3.0.0,<4.0.0",
+    "numpy>=1.21.0",
+    "pyarrow>=14.0.0",
+    "typer>=0.9.0",
+]
+
+[project.scripts]
+nn-pipeline = "cli.build_ragpack:app"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["chunker*", "embedder*", "ragpack*", "cli*"]
+

--- a/ragpack/__init__.py
+++ b/ragpack/__init__.py
@@ -1,0 +1,21 @@
+"""
+noesisnoema-pipeline ragpack module.
+
+Provides deterministic RAGPack artifact generation (EPIC3 Stage 3).
+
+Public API
+----------
+    from ragpack import ManifestBuilder, Ragpack, RagpackBuilder, RagpackWriter
+"""
+
+from .manifest_builder import ManifestBuilder
+from .ragpack_builder import Ragpack, RagpackBuilder
+from .ragpack_writer import RagpackWriter
+
+__all__ = [
+    "ManifestBuilder",
+    "Ragpack",
+    "RagpackBuilder",
+    "RagpackWriter",
+]
+

--- a/ragpack/manifest_builder.py
+++ b/ragpack/manifest_builder.py
@@ -1,0 +1,169 @@
+"""
+ManifestBuilder — constructs the canonical RAGPack manifest dict.
+
+Design contract (EPIC3 Stage 3)
+--------------------------------
+- All required fields are explicit constructor arguments; nothing is inferred
+  silently or read from global state.
+- creation_time is accepted as a caller-supplied string so that the manifest
+  is fully reproducible in tests without patching datetime.
+- The dict produced by build() is the single source of truth fed to
+  manifest.json.  It carries all fields required by manifest_v1_1.json.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Required manifest field names (kept as module-level constants so callers
+# can assert completeness without hard-coding string literals).
+# ---------------------------------------------------------------------------
+
+REQUIRED_MANIFEST_FIELDS = frozenset({
+    "ragpack_version",
+    "creation_time",
+    "chunk_count",
+    "embedding_model",
+    "embedding_dimension",
+    "model_hash",
+    "chunking_config_hash",
+    "dtype",
+})
+
+
+def _manifest_hash(manifest_body: dict) -> str:
+    """
+    Return a SHA-256 hex digest of the manifest body (excluding the hash
+    field itself) serialised as canonically sorted JSON.
+
+    This hash lets consumers verify that a manifest has not been tampered
+    with after generation.
+    """
+    canonical = json.dumps(manifest_body, sort_keys=True, ensure_ascii=True,
+                           default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+class ManifestBuilder:
+    """
+    Constructs the canonical manifest.json content for a RAGPack.
+
+    All fields that affect reproducibility are required at construction time.
+    Optional fields (source_documents, extra_metadata) may be supplied but
+    the manifest is valid without them.
+
+    Usage
+    -----
+    ::
+
+        builder = ManifestBuilder(
+            chunk_count=42,
+            embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+            embedding_dimension=384,
+            model_hash="abc...",
+            chunking_config_hash="def...",
+            dtype="float32",
+            creation_time="2026-03-06T00:00:00",
+            embedding_version="3.4.1",
+        )
+        manifest = builder.build()
+    """
+
+    #: Bump this when the manifest schema changes in a breaking way.
+    RAGPACK_VERSION: str = "1.2"
+
+    def __init__(
+        self,
+        *,
+        chunk_count: int,
+        embedding_model: str,
+        embedding_dimension: int,
+        model_hash: str,
+        chunking_config_hash: str,
+        dtype: str,
+        creation_time: str,
+        embedding_version: str = "",
+        source_documents: list | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Args:
+            chunk_count:          Total number of chunks in the pack.
+            embedding_model:      HuggingFace model identifier.
+            embedding_dimension:  Number of dimensions per vector.
+            model_hash:           SHA-256 of the model configuration dict.
+            chunking_config_hash: SHA-256 of the chunking configuration dict.
+            dtype:                NumPy dtype string (e.g. "float32").
+            creation_time:        ISO-8601 timestamp string (caller-supplied
+                                  so the manifest is reproducible in tests).
+            embedding_version:    Library version string (optional).
+            source_documents:     Optional list of source document dicts.
+            extra_metadata:       Optional dict of additional top-level fields.
+        """
+        if chunk_count < 0:
+            raise ValueError("chunk_count must be >= 0")
+        if not embedding_model:
+            raise ValueError("embedding_model must not be empty")
+        if embedding_dimension < 1:
+            raise ValueError("embedding_dimension must be >= 1")
+        if not model_hash:
+            raise ValueError("model_hash must not be empty")
+        if not chunking_config_hash:
+            raise ValueError("chunking_config_hash must not be empty")
+        if not dtype:
+            raise ValueError("dtype must not be empty")
+        if not creation_time:
+            raise ValueError("creation_time must not be empty")
+
+        self._chunk_count = chunk_count
+        self._embedding_model = embedding_model
+        self._embedding_dimension = embedding_dimension
+        self._model_hash = model_hash
+        self._chunking_config_hash = chunking_config_hash
+        self._dtype = dtype
+        self._creation_time = creation_time
+        self._embedding_version = embedding_version
+        self._source_documents = source_documents or []
+        self._extra_metadata = extra_metadata or {}
+
+    def build(self) -> dict[str, Any]:
+        """
+        Return the complete manifest as a plain dict.
+
+        The dict is deterministic: given the same constructor arguments it
+        always produces the same JSON-serialisable output.  A
+        ``manifest_hash`` field is appended last so it can be used by
+        consumers to verify integrity.
+        """
+        body: dict[str, Any] = {
+            "ragpack_version": self.RAGPACK_VERSION,
+            "creation_time": self._creation_time,
+            "chunk_count": self._chunk_count,
+            "embedding_model": self._embedding_model,
+            "embedding_version": self._embedding_version,
+            "embedding_dimension": self._embedding_dimension,
+            "model_hash": self._model_hash,
+            "chunking_config_hash": self._chunking_config_hash,
+            "dtype": self._dtype,
+            "files": {
+                "embeddings": "embeddings.npy",
+                "chunks": "chunks.parquet",
+                "manifest": "manifest.json",
+            },
+            "source_documents": self._source_documents,
+        }
+
+        # Merge caller-supplied extra fields (they must not override required keys)
+        for key, value in self._extra_metadata.items():
+            if key not in REQUIRED_MANIFEST_FIELDS and key != "files":
+                body[key] = value
+
+        # Append integrity hash computed over the body built so far
+        body["manifest_hash"] = _manifest_hash(body)
+
+        return body
+

--- a/ragpack/ragpack_builder.py
+++ b/ragpack/ragpack_builder.py
@@ -1,0 +1,180 @@
+"""
+RagpackBuilder — orchestrates chunk embedding and Ragpack assembly.
+
+Design contract (EPIC3 Stage 3)
+--------------------------------
+- Single explicit entry point: RagpackBuilder.build().
+- No background threads, no hidden side effects, no autonomous retries.
+- Chunk order in the output is identical to the input order.
+- All non-determinism in the pipeline is eliminated before this layer;
+  this module only assembles what the embedder already produced.
+- creation_time is an explicit parameter (ISO-8601 string) so callers
+  control reproducibility in tests without patching datetime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import numpy as np
+
+from chunker.chunk_record import ChunkRecord
+from embedder.deterministic_embedder import DeterministicEmbedder, EmbeddingResult
+from .manifest_builder import ManifestBuilder
+
+
+# ---------------------------------------------------------------------------
+# Ragpack — the output value object
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Ragpack:
+    """
+    Immutable output of a single RagpackBuilder.build() call.
+
+    Fields
+    ------
+    chunks        Ordered list of ChunkRecord objects, one per row of embeddings.
+    embeddings    np.ndarray of shape (N, D), dtype float32.  Row i matches
+                  chunks[i].
+    manifest      Plain dict ready for JSON serialisation as manifest.json.
+    chunk_ids     Ordered list of chunk_id strings, aligned with chunks and
+                  embedding rows, for fast lookup without iterating ChunkRecords.
+    """
+
+    chunks: List[ChunkRecord]
+    embeddings: np.ndarray
+    manifest: dict
+    chunk_ids: List[str]
+
+    def __post_init__(self) -> None:
+        if self.embeddings.ndim != 2:
+            raise ValueError(
+                f"embeddings must be 2-D, got shape {self.embeddings.shape}"
+            )
+        if self.embeddings.shape[0] != len(self.chunks):
+            raise ValueError(
+                f"embeddings row count ({self.embeddings.shape[0]}) must equal "
+                f"len(chunks) ({len(self.chunks)})"
+            )
+        if len(self.chunk_ids) != len(self.chunks):
+            raise ValueError(
+                f"len(chunk_ids) ({len(self.chunk_ids)}) must equal "
+                f"len(chunks) ({len(self.chunks)})"
+            )
+        # Verify chunk_ids alignment
+        for idx, (cid, chunk) in enumerate(zip(self.chunk_ids, self.chunks)):
+            if cid != chunk.chunk_id:
+                raise ValueError(
+                    f"chunk_ids[{idx}] ('{cid}') does not match "
+                    f"chunks[{idx}].chunk_id ('{chunk.chunk_id}')"
+                )
+
+
+# ---------------------------------------------------------------------------
+# RagpackBuilder
+# ---------------------------------------------------------------------------
+
+class RagpackBuilder:
+    """
+    Orchestrates embedding of ChunkRecord objects and assembles a Ragpack.
+
+    The builder is stateless between calls to build(); construct a new
+    instance or reuse one — both are safe.
+
+    Usage
+    -----
+    ::
+
+        embedder = DeterministicEmbedder()
+        builder  = RagpackBuilder(embedder)
+        ragpack  = builder.build(
+            chunks=chunk_records,
+            creation_time="2026-03-06T00:00:00",
+        )
+    """
+
+    def __init__(self, embedder: DeterministicEmbedder) -> None:
+        """
+        Args:
+            embedder: A fully initialised DeterministicEmbedder.  The same
+                      embedder instance may be reused across multiple build()
+                      calls; it carries no mutable per-build state.
+        """
+        if not isinstance(embedder, DeterministicEmbedder):
+            raise TypeError(
+                f"embedder must be a DeterministicEmbedder, "
+                f"got {type(embedder).__name__}"
+            )
+        self._embedder = embedder
+
+    def build(
+        self,
+        chunks: Sequence[ChunkRecord],
+        creation_time: str,
+        source_documents: list | None = None,
+    ) -> Ragpack:
+        """
+        Embed all chunks and assemble the complete Ragpack.
+
+        Args:
+            chunks:           Ordered sequence of ChunkRecord objects.
+            creation_time:    ISO-8601 timestamp string, supplied by the caller
+                              so the output is reproducible in tests without
+                              patching datetime.
+            source_documents: Optional list of source document metadata dicts
+                              to embed in the manifest.
+
+        Returns:
+            A fully populated, immutable Ragpack.
+
+        Raises:
+            TypeError:  if any element of chunks is not a ChunkRecord.
+            ValueError: if creation_time is empty.
+        """
+        if not creation_time:
+            raise ValueError("creation_time must not be empty")
+
+        # Validate input types explicitly — fail fast, no silent coercion.
+        for idx, chunk in enumerate(chunks):
+            if not isinstance(chunk, ChunkRecord):
+                raise TypeError(
+                    f"chunks[{idx}] must be a ChunkRecord, "
+                    f"got {type(chunk).__name__}"
+                )
+
+        chunk_list = list(chunks)
+
+        # --- Embed in input order; EmbeddingResult.chunk_ids is aligned ---
+        embedding_result: EmbeddingResult = self._embedder.embed_chunks(chunk_list)
+
+        # Derive chunking_config_hash from the first chunk (all chunks from
+        # the same chunker share the same config hash; the manifest needs one
+        # representative value).  Use the sentinel "empty" when there are no
+        # chunks so the manifest field remains non-empty and self-documenting.
+        chunking_config_hash = (
+            chunk_list[0].chunking_config_hash if chunk_list else "empty"
+        )
+
+        meta = self._embedder.metadata
+        manifest_builder = ManifestBuilder(
+            chunk_count=len(chunk_list),
+            embedding_model=meta.embedding_model,
+            embedding_dimension=meta.embedding_dimension,
+            model_hash=meta.model_hash,
+            chunking_config_hash=chunking_config_hash,
+            dtype=meta.dtype,
+            creation_time=creation_time,
+            embedding_version=meta.embedding_version,
+            source_documents=source_documents,
+        )
+        manifest = manifest_builder.build()
+
+        return Ragpack(
+            chunks=chunk_list,
+            embeddings=embedding_result.embeddings,
+            manifest=manifest,
+            chunk_ids=embedding_result.chunk_ids,
+        )
+

--- a/ragpack/ragpack_writer.py
+++ b/ragpack/ragpack_writer.py
@@ -1,0 +1,182 @@
+"""
+RagpackWriter — writes a Ragpack to a directory on disk.
+
+Design contract (EPIC3 Stage 3)
+--------------------------------
+- Writes exactly three files: embeddings.npy, chunks.parquet, manifest.json.
+- All three files are written deterministically: given the same Ragpack the
+  byte content of each file is identical across runs.
+- embeddings.npy uses np.save (standard NumPy binary format).
+- chunks.parquet uses pyarrow with fixed schema, no dictionary encoding,
+  sorted column order, and snappy compression (reproducible).
+- manifest.json uses json.dumps with sort_keys=True and indent=2.
+- The writer does NOT modify the Ragpack object or the existing PackWriter.
+- output_dir is created (including parents) if it does not exist.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .ragpack_builder import Ragpack
+
+
+# ---------------------------------------------------------------------------
+# Parquet column schema (fixed order — column order must never change)
+# ---------------------------------------------------------------------------
+
+_CHUNKS_SCHEMA = pa.schema([
+    pa.field("chunk_id",              pa.string(),  nullable=False),
+    pa.field("source_id",             pa.string(),  nullable=False),
+    pa.field("source_path",           pa.string(),  nullable=False),
+    pa.field("source_hash",           pa.string(),  nullable=False),
+    pa.field("chunk_index",           pa.int64(),   nullable=False),
+    pa.field("char_start",            pa.int64(),   nullable=False),
+    pa.field("char_end",              pa.int64(),   nullable=False),
+    pa.field("token_count",           pa.int64(),   nullable=False),
+    pa.field("text_snippet",          pa.string(),  nullable=False),
+    pa.field("chunk_text_hash",       pa.string(),  nullable=False),
+    pa.field("chunking_config_hash",  pa.string(),  nullable=False),
+    pa.field("section",               pa.string(),  nullable=True),
+    pa.field("page",                  pa.int64(),   nullable=True),
+])
+
+
+def _chunks_to_arrow_table(ragpack: Ragpack) -> pa.Table:
+    """Convert the ChunkRecord list in a Ragpack to a pyarrow Table."""
+    columns: dict = {field.name: [] for field in _CHUNKS_SCHEMA}
+
+    for chunk in ragpack.chunks:
+        columns["chunk_id"].append(chunk.chunk_id)
+        columns["source_id"].append(chunk.source_id)
+        columns["source_path"].append(chunk.source_path)
+        columns["source_hash"].append(chunk.source_hash)
+        columns["chunk_index"].append(chunk.chunk_index)
+        columns["char_start"].append(chunk.char_start)
+        columns["char_end"].append(chunk.char_end)
+        columns["token_count"].append(chunk.token_count)
+        columns["text_snippet"].append(chunk.text_snippet)
+        columns["chunk_text_hash"].append(chunk.chunk_text_hash)
+        columns["chunking_config_hash"].append(chunk.chunking_config_hash)
+        columns["section"].append(chunk.section)
+        columns["page"].append(chunk.page)
+
+    arrays = [
+        pa.array(columns[field.name], type=field.type)
+        for field in _CHUNKS_SCHEMA
+    ]
+    return pa.table(arrays, schema=_CHUNKS_SCHEMA)
+
+
+class RagpackWriter:
+    """
+    Writes a Ragpack to a target directory, producing exactly:
+
+        <output_dir>/
+            embeddings.npy
+            chunks.parquet
+            manifest.json
+
+    All three files are written deterministically.
+
+    Usage
+    -----
+    ::
+
+        writer = RagpackWriter()
+        paths  = writer.write(ragpack, output_dir="ragpack/")
+    """
+
+    def write(
+        self,
+        ragpack: Ragpack,
+        output_dir: Union[str, Path],
+    ) -> dict[str, Path]:
+        """
+        Write the Ragpack to output_dir.
+
+        Args:
+            ragpack:    A fully assembled Ragpack (from RagpackBuilder.build()).
+            output_dir: Target directory path.  Created (including parents)
+                        if it does not exist.
+
+        Returns:
+            Dict mapping artifact name to absolute Path:
+            ``{"embeddings": ..., "chunks": ..., "manifest": ...}``
+
+        Raises:
+            TypeError:  if ragpack is not a Ragpack instance.
+            ValueError: if output_dir resolves to an existing file (not a dir).
+        """
+        if not isinstance(ragpack, Ragpack):
+            raise TypeError(
+                f"ragpack must be a Ragpack, got {type(ragpack).__name__}"
+            )
+
+        target = Path(output_dir).resolve()
+        if target.exists() and not target.is_dir():
+            raise ValueError(
+                f"output_dir '{target}' exists and is a file, not a directory"
+            )
+        target.mkdir(parents=True, exist_ok=True)
+
+        embeddings_path = self._write_embeddings(ragpack, target)
+        chunks_path     = self._write_chunks(ragpack, target)
+        manifest_path   = self._write_manifest(ragpack, target)
+
+        return {
+            "embeddings": embeddings_path,
+            "chunks":     chunks_path,
+            "manifest":   manifest_path,
+        }
+
+    # ------------------------------------------------------------------
+    # Private writers — each writes one file deterministically
+    # ------------------------------------------------------------------
+
+    def _write_embeddings(self, ragpack: Ragpack, target: Path) -> Path:
+        """Write embeddings as a standard NumPy .npy file."""
+        path = target / "embeddings.npy"
+        np.save(str(path), ragpack.embeddings)
+        return path
+
+    def _write_chunks(self, ragpack: Ragpack, target: Path) -> Path:
+        """
+        Write chunks as a Parquet file.
+
+        Determinism controls:
+        - Fixed pyarrow schema with explicit column order.
+        - No dictionary encoding (dictionary pages are order-sensitive).
+        - data_page_version="1.0" for maximum reader compatibility.
+        - write_statistics=False eliminates any non-deterministic stat blobs.
+        - snappy compression is deterministic for the same input bytes.
+        - Row group size fixed at 128 MB (effectively one row group for
+          typical packs) to avoid split-point non-determinism.
+        """
+        path = target / "chunks.parquet"
+        table = _chunks_to_arrow_table(ragpack)
+        pq.write_table(
+            table,
+            str(path),
+            compression="snappy",
+            use_dictionary=False,
+            data_page_version="1.0",
+            write_statistics=False,
+            row_group_size=128 * 1024 * 1024,
+        )
+        return path
+
+    def _write_manifest(self, ragpack: Ragpack, target: Path) -> Path:
+        """Write manifest as UTF-8 JSON with stable key ordering."""
+        path = target / "manifest.json"
+        content = json.dumps(ragpack.manifest, sort_keys=True, indent=2,
+                             ensure_ascii=False, default=str)
+        path.write_text(content, encoding="utf-8")
+        return path
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,21 @@
 # noesisnoema-pipeline
-# Deterministic RagPack Generator (no retrieval, no embedding)
+# Deterministic RAGPack Generator
 
 # Token-based chunking
 transformers>=4.20.0
 
-# Numerical utilities (if used by validation logic)
+# Deterministic embedding generation (EPIC3 Stage 2)
+sentence-transformers>=3.0.0,<4.0.0
+
+# Numerical utilities
 numpy>=1.21.0
+
+# Parquet serialisation for chunks.parquet (EPIC3 Stage 3)
+pyarrow>=14.0.0
+
+# CLI entrypoint (EPIC3 Stage 3)
+typer>=0.9.0
 
 # Testing
 pytest>=6.0.0
+

--- a/schemas/manifest_v1_1.json
+++ b/schemas/manifest_v1_1.json
@@ -52,29 +52,50 @@
         "preserve_sentences": {
           "type": "boolean",
           "description": "Whether sentence boundaries were preserved"
+        },
+        "config_hash": {
+          "type": "string",
+          "description": "SHA-256 hex digest of the full chunking configuration; stable reproducibility key"
         }
       }
     },
     "embedder": {
       "type": "object",
-      "required": ["name", "version", "dimensions"],
+      "required": ["embedding_model", "embedding_version", "embedding_dimension", "model_hash", "dtype"],
       "properties": {
+        "embedding_model": {
+          "type": "string",
+          "description": "HuggingFace model identifier or local path used to generate embeddings"
+        },
+        "embedding_version": {
+          "type": "string",
+          "description": "Version of the sentence-transformers library that produced the embeddings"
+        },
+        "embedding_dimension": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of dimensions in each output embedding vector"
+        },
+        "model_hash": {
+          "type": "string",
+          "description": "SHA-256 hex digest of the model configuration; stable identity check for reproducibility"
+        },
+        "dtype": {
+          "type": "string",
+          "description": "NumPy dtype of the output embedding array (e.g. float32)"
+        },
         "name": {
           "type": "string",
-          "description": "Name of the embedding model"
+          "description": "Legacy alias for embedding_model; kept for backward compatibility"
         },
         "version": {
           "type": "string",
-          "description": "Version of the embedding model"
-        },
-        "hash": {
-          "type": "string",
-          "description": "Hash of the model for verification"
+          "description": "Legacy alias for embedding_version; kept for backward compatibility"
         },
         "dimensions": {
           "type": "integer",
           "minimum": 1,
-          "description": "Dimensionality of embeddings"
+          "description": "Legacy alias for embedding_dimension; kept for backward compatibility"
         }
       }
     },

--- a/tests/test_chunk_record.py
+++ b/tests/test_chunk_record.py
@@ -1,0 +1,576 @@
+"""
+Stage 1 contract tests: deterministic chunk_id, complete metadata, repeatability.
+
+Tests in this file validate the EPIC3 Stage 1 deliverables:
+- test_chunk_id_deterministic  — identical inputs always produce the same chunk_id
+- test_chunk_metadata_complete — every required field is present and correctly typed
+- test_chunk_repeatability     — two independent chunking runs produce identical records
+"""
+
+import unittest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chunker import (
+    ChunkRecord,
+    TokenChunker,
+    compute_chunk_id,
+    build_snippet,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SOURCE_ID = "src-abc123"
+_SOURCE_PATH = "docs/sample.txt"
+_SOURCE_HASH = "a" * 64  # placeholder SHA-256 hex string
+_TEXT = (
+    "Artificial intelligence is transforming every industry. "
+    "Machine learning models learn from data to make predictions. "
+    "Natural language processing enables computers to understand human text. "
+    "Deep learning uses many-layered neural networks for complex tasks. "
+) * 4  # repeat to ensure multiple chunks with small chunk sizes
+
+
+def _make_chunker(**overrides) -> TokenChunker:
+    defaults = dict(chunk_size=20, overlap=5, preserve_sentences=False)
+    defaults.update(overrides)
+    return TokenChunker(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# chunk_id helpers
+# ---------------------------------------------------------------------------
+
+class TestComputeChunkId(unittest.TestCase):
+    """Unit tests for the compute_chunk_id function."""
+
+    def _make_id(self, **overrides) -> str:
+        kwargs = dict(
+            source_id=_SOURCE_ID,
+            char_start=0,
+            char_end=100,
+            chunk_text_hash="b" * 64,
+            chunking_config_hash="c" * 64,
+        )
+        kwargs.update(overrides)
+        return compute_chunk_id(**kwargs)
+
+    def test_returns_64_char_hex_string(self):
+        """chunk_id should be a 64-character lowercase hex string (SHA-256)."""
+        chunk_id = self._make_id()
+        self.assertEqual(len(chunk_id), 64)
+        self.assertTrue(all(ch in "0123456789abcdef" for ch in chunk_id))
+
+    def test_same_inputs_same_output(self):
+        """Identical inputs must always produce the same chunk_id."""
+        id_a = self._make_id()
+        id_b = self._make_id()
+        self.assertEqual(id_a, id_b)
+
+    def test_different_source_id_different_output(self):
+        """A different source_id must change the chunk_id."""
+        id_a = self._make_id(source_id="src-aaa")
+        id_b = self._make_id(source_id="src-bbb")
+        self.assertNotEqual(id_a, id_b)
+
+    def test_different_char_start_different_output(self):
+        """A different char_start must change the chunk_id."""
+        id_a = self._make_id(char_start=0)
+        id_b = self._make_id(char_start=1)
+        self.assertNotEqual(id_a, id_b)
+
+    def test_different_char_end_different_output(self):
+        """A different char_end must change the chunk_id."""
+        id_a = self._make_id(char_end=100)
+        id_b = self._make_id(char_end=101)
+        self.assertNotEqual(id_a, id_b)
+
+    def test_different_chunk_text_hash_different_output(self):
+        """A different chunk_text_hash must change the chunk_id."""
+        id_a = self._make_id(chunk_text_hash="b" * 64)
+        id_b = self._make_id(chunk_text_hash="c" * 64)
+        self.assertNotEqual(id_a, id_b)
+
+    def test_different_config_hash_different_output(self):
+        """A different chunking_config_hash must change the chunk_id."""
+        id_a = self._make_id(chunking_config_hash="c" * 64)
+        id_b = self._make_id(chunking_config_hash="d" * 64)
+        self.assertNotEqual(id_a, id_b)
+
+    def test_empty_source_id_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_id(source_id="")
+
+    def test_negative_char_start_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_id(char_start=-1)
+
+    def test_char_end_not_greater_than_start_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_id(char_start=10, char_end=10)
+
+
+# ---------------------------------------------------------------------------
+# test_chunk_id_deterministic
+# ---------------------------------------------------------------------------
+
+class TestChunkIdDeterministic(unittest.TestCase):
+    """chunk_id must be deterministic: same source + config → same ids."""
+
+    def test_chunk_id_deterministic_single_run(self):
+        """
+        Two calls to chunk_document with identical inputs must produce
+        chunk records with identical chunk_ids in the same order.
+        """
+        chunker = _make_chunker()
+        records_a = chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+        records_b = chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+
+        self.assertGreater(len(records_a), 0, "Expected at least one chunk")
+        self.assertEqual(len(records_a), len(records_b))
+        for rec_a, rec_b in zip(records_a, records_b):
+            self.assertEqual(rec_a.chunk_id, rec_b.chunk_id)
+
+    def test_chunk_id_changes_when_source_id_changes(self):
+        """Changing source_id must produce different chunk_ids."""
+        chunker = _make_chunker()
+        records_a = chunker.chunk_document(
+            text=_TEXT,
+            source_id="src-001",
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+        records_b = chunker.chunk_document(
+            text=_TEXT,
+            source_id="src-002",
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+
+        self.assertEqual(len(records_a), len(records_b))
+        for rec_a, rec_b in zip(records_a, records_b):
+            self.assertNotEqual(rec_a.chunk_id, rec_b.chunk_id)
+
+    def test_chunk_ids_are_unique_within_document(self):
+        """Each chunk in a document must have a distinct chunk_id."""
+        chunker = _make_chunker()
+        records = chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+        self.assertGreater(len(records), 1, "Need multiple chunks for this test")
+        ids = [r.chunk_id for r in records]
+        self.assertEqual(len(ids), len(set(ids)), "chunk_ids must be unique")
+
+    def test_chunk_id_is_64_char_hex(self):
+        """chunk_id must be a 64-character lowercase SHA-256 hex string."""
+        chunker = _make_chunker()
+        records = chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+        for record in records:
+            self.assertEqual(len(record.chunk_id), 64)
+            self.assertTrue(
+                all(ch in "0123456789abcdef" for ch in record.chunk_id),
+                f"Non-hex character in chunk_id: {record.chunk_id}",
+            )
+
+    def test_chunk_id_does_not_change_with_new_chunker_instance(self):
+        """
+        A new TokenChunker with identical config must produce the same
+        chunk_ids as a prior instance — config_hash must be stable.
+        """
+        chunker_1 = _make_chunker()
+        chunker_2 = _make_chunker()
+
+        records_1 = chunker_1.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+        records_2 = chunker_2.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+
+        self.assertEqual(len(records_1), len(records_2))
+        for r1, r2 in zip(records_1, records_2):
+            self.assertEqual(r1.chunk_id, r2.chunk_id)
+
+
+# ---------------------------------------------------------------------------
+# test_chunk_metadata_complete
+# ---------------------------------------------------------------------------
+
+class TestChunkMetadataComplete(unittest.TestCase):
+    """Every ChunkRecord must carry the complete EPIC3 Stage 1 field set."""
+
+    REQUIRED_FIELDS = {
+        "chunk_id",
+        "source_id",
+        "source_path",
+        "source_hash",
+        "chunk_index",
+        "char_start",
+        "char_end",
+        "token_count",
+        "text_snippet",
+        "chunk_text_hash",
+        "chunking_config_hash",
+    }
+
+    def _get_records(self) -> list:
+        chunker = _make_chunker()
+        return chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+
+    def test_all_required_fields_present(self):
+        """to_dict() must include every required field."""
+        for record in self._get_records():
+            record_dict = record.to_dict()
+            for field_name in self.REQUIRED_FIELDS:
+                self.assertIn(
+                    field_name,
+                    record_dict,
+                    f"Required field '{field_name}' missing from chunk record",
+                )
+
+    def test_source_id_matches_input(self):
+        for record in self._get_records():
+            self.assertEqual(record.source_id, _SOURCE_ID)
+
+    def test_source_path_matches_input(self):
+        for record in self._get_records():
+            self.assertEqual(record.source_path, _SOURCE_PATH)
+
+    def test_source_hash_matches_input(self):
+        for record in self._get_records():
+            self.assertEqual(record.source_hash, _SOURCE_HASH)
+
+    def test_chunk_index_sequential_zero_based(self):
+        """chunk_index must be a zero-based, monotonically increasing integer."""
+        records = self._get_records()
+        for expected_index, record in enumerate(records):
+            self.assertEqual(record.chunk_index, expected_index)
+
+    def test_char_start_and_end_are_valid_offsets(self):
+        """char_start must be non-negative, char_end must exceed char_start."""
+        for record in self._get_records():
+            self.assertGreaterEqual(record.char_start, 0)
+            self.assertGreater(record.char_end, record.char_start)
+
+    def test_token_count_is_positive_int(self):
+        for record in self._get_records():
+            self.assertIsInstance(record.token_count, int)
+            self.assertGreater(record.token_count, 0)
+
+    def test_text_snippet_is_string_and_not_empty(self):
+        for record in self._get_records():
+            self.assertIsInstance(record.text_snippet, str)
+            self.assertGreater(len(record.text_snippet), 0)
+
+    def test_text_snippet_max_length(self):
+        """text_snippet must not exceed 203 characters (200 + '...')."""
+        for record in self._get_records():
+            self.assertLessEqual(len(record.text_snippet), 203)
+
+    def test_chunk_text_hash_is_64_char_hex(self):
+        for record in self._get_records():
+            self.assertEqual(len(record.chunk_text_hash), 64)
+            self.assertTrue(
+                all(ch in "0123456789abcdef" for ch in record.chunk_text_hash)
+            )
+
+    def test_chunking_config_hash_is_64_char_hex(self):
+        for record in self._get_records():
+            self.assertEqual(len(record.chunking_config_hash), 64)
+            self.assertTrue(
+                all(ch in "0123456789abcdef" for ch in record.chunking_config_hash)
+            )
+
+    def test_chunking_config_hash_same_for_all_chunks(self):
+        """All chunks from the same chunker instance share the config hash."""
+        records = self._get_records()
+        hashes = {r.chunking_config_hash for r in records}
+        self.assertEqual(len(hashes), 1, "All chunks must share the same config hash")
+
+    def test_optional_section_defaults_to_none(self):
+        for record in self._get_records():
+            self.assertIsNone(record.section)
+
+    def test_optional_page_defaults_to_none(self):
+        for record in self._get_records():
+            self.assertIsNone(record.page)
+
+    def test_section_and_page_propagated_when_supplied(self):
+        """section and page are forwarded to every chunk when supplied."""
+        chunker = _make_chunker()
+        records = chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+            section="Introduction",
+            page=3,
+        )
+        for record in records:
+            self.assertEqual(record.section, "Introduction")
+            self.assertEqual(record.page, 3)
+
+    def test_chunk_id_is_not_integer_sequence(self):
+        """chunk_id must be a hash string, never a plain integer index."""
+        for record in self._get_records():
+            self.assertIsInstance(record.chunk_id, str)
+            # A SHA-256 hex string contains letters so int() will always raise
+            with self.assertRaises(ValueError):
+                int(record.chunk_id, 10)  # base-10 parse fails on hex letters
+
+    def test_to_dict_serialises_all_required_fields(self):
+        """to_dict() output must include every required field as a key."""
+        for record in self._get_records():
+            d = record.to_dict()
+            for field_name in self.REQUIRED_FIELDS:
+                self.assertIn(field_name, d)
+
+    def test_get_chunker_metadata_includes_config_hash(self):
+        """get_chunker_metadata() must expose 'config_hash' for manifest use."""
+        chunker = _make_chunker()
+        metadata = chunker.get_chunker_metadata()
+        self.assertIn("config_hash", metadata)
+        self.assertEqual(len(metadata["config_hash"]), 64)
+
+
+# ---------------------------------------------------------------------------
+# test_chunk_repeatability
+# ---------------------------------------------------------------------------
+
+class TestChunkRepeatability(unittest.TestCase):
+    """
+    Two independent chunking runs with identical inputs must produce
+    byte-for-byte identical ChunkRecord objects.
+    """
+
+    def _run(self, text: str, **chunker_kwargs) -> list:
+        chunker = TokenChunker(**chunker_kwargs)
+        return chunker.chunk_document(
+            text=text,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+
+    def test_identical_records_on_repeated_run(self):
+        """Two runs must produce identical records in order."""
+        kwargs = dict(chunk_size=20, overlap=5, preserve_sentences=False)
+        run_a = self._run(_TEXT, **kwargs)
+        run_b = self._run(_TEXT, **kwargs)
+
+        self.assertEqual(len(run_a), len(run_b))
+        for rec_a, rec_b in zip(run_a, run_b):
+            self.assertEqual(rec_a.to_dict(), rec_b.to_dict())
+
+    def test_no_stray_nondeterminism_in_single_chunk_case(self):
+        """A text shorter than chunk_size must always produce one stable record."""
+        short_text = "A short sentence."
+        kwargs = dict(chunk_size=100, overlap=0)
+        run_a = self._run(short_text, **kwargs)
+        run_b = self._run(short_text, **kwargs)
+
+        self.assertEqual(len(run_a), 1)
+        self.assertEqual(run_a[0].to_dict(), run_b[0].to_dict())
+
+    def test_config_hash_stable_across_instances(self):
+        """config_hash must be identical for two TokenChunker instances with same config."""
+        chunker_a = TokenChunker(chunk_size=64, overlap=8, preserve_sentences=True)
+        chunker_b = TokenChunker(chunk_size=64, overlap=8, preserve_sentences=True)
+        self.assertEqual(chunker_a._config_hash, chunker_b._config_hash)
+
+    def test_different_config_produces_different_config_hash(self):
+        """Different chunking config must produce different config_hash."""
+        chunker_a = TokenChunker(chunk_size=64, overlap=8)
+        chunker_b = TokenChunker(chunk_size=128, overlap=8)
+        self.assertNotEqual(chunker_a._config_hash, chunker_b._config_hash)
+
+    def test_chunk_text_hash_matches_manual_computation(self):
+        """chunk_text_hash must equal sha256(chunk_text, utf-8)."""
+        import hashlib
+
+        chunker = _make_chunker()
+        records = chunker.chunk_document(
+            text=_TEXT,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+        )
+        for record in records:
+            # Retrieve the original chunk text via the char offsets.
+            # Do NOT strip _TEXT here: the chunker strips internally and
+            # records offsets relative to the stripped text, so slicing
+            # the un-stripped source with those offsets gives the wrong
+            # characters. Use _TEXT directly so offsets are consistent.
+            original_text = _TEXT
+            chunk_text = original_text[record.char_start: record.char_end]
+            expected_hash = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+            self.assertEqual(
+                record.chunk_text_hash,
+                expected_hash,
+                f"chunk_text_hash mismatch for chunk_index={record.chunk_index}",
+            )
+
+    def test_repeatability_with_unicode_text(self):
+        """Unicode source text must produce stable records across runs."""
+        unicode_text = (
+            "Привет мир. " * 8
+            + "日本語テスト。" * 8
+            + "こんにちは 🌍 " * 8
+        )
+        kwargs = dict(chunk_size=15, overlap=3, preserve_sentences=False)
+        run_a = self._run(unicode_text, **kwargs)
+        run_b = self._run(unicode_text, **kwargs)
+
+        self.assertEqual(len(run_a), len(run_b))
+        for rec_a, rec_b in zip(run_a, run_b):
+            self.assertEqual(rec_a.to_dict(), rec_b.to_dict())
+
+    def test_empty_text_produces_empty_list(self):
+        """Empty / whitespace-only input must produce an empty record list."""
+        chunker = _make_chunker()
+        for text in ("", "   ", "\n\t"):
+            records = chunker.chunk_document(
+                text=text,
+                source_id=_SOURCE_ID,
+                source_path=_SOURCE_PATH,
+                source_hash=_SOURCE_HASH,
+            )
+            self.assertEqual(records, [])
+
+
+# ---------------------------------------------------------------------------
+# ChunkRecord dataclass invariant tests
+# ---------------------------------------------------------------------------
+
+class TestChunkRecordInvariants(unittest.TestCase):
+    """ChunkRecord must enforce its field invariants at construction time."""
+
+    def _valid_kwargs(self) -> dict:
+        return dict(
+            chunk_id="a" * 64,
+            source_id=_SOURCE_ID,
+            source_path=_SOURCE_PATH,
+            source_hash=_SOURCE_HASH,
+            chunk_index=0,
+            char_start=0,
+            char_end=50,
+            token_count=10,
+            text_snippet="Hello world",
+            chunk_text_hash="b" * 64,
+            chunking_config_hash="c" * 64,
+        )
+
+    def test_valid_record_constructs_without_error(self):
+        record = ChunkRecord(**self._valid_kwargs())
+        self.assertIsInstance(record, ChunkRecord)
+
+    def test_empty_chunk_id_raises(self):
+        kwargs = self._valid_kwargs()
+        kwargs["chunk_id"] = ""
+        with self.assertRaises(ValueError):
+            ChunkRecord(**kwargs)
+
+    def test_negative_chunk_index_raises(self):
+        kwargs = self._valid_kwargs()
+        kwargs["chunk_index"] = -1
+        with self.assertRaises(ValueError):
+            ChunkRecord(**kwargs)
+
+    def test_negative_char_start_raises(self):
+        kwargs = self._valid_kwargs()
+        kwargs["char_start"] = -1
+        with self.assertRaises(ValueError):
+            ChunkRecord(**kwargs)
+
+    def test_char_end_equal_to_char_start_raises(self):
+        kwargs = self._valid_kwargs()
+        kwargs["char_start"] = 10
+        kwargs["char_end"] = 10
+        with self.assertRaises(ValueError):
+            ChunkRecord(**kwargs)
+
+    def test_char_end_less_than_char_start_raises(self):
+        kwargs = self._valid_kwargs()
+        kwargs["char_start"] = 10
+        kwargs["char_end"] = 5
+        with self.assertRaises(ValueError):
+            ChunkRecord(**kwargs)
+
+    def test_zero_token_count_raises(self):
+        kwargs = self._valid_kwargs()
+        kwargs["token_count"] = 0
+        with self.assertRaises(ValueError):
+            ChunkRecord(**kwargs)
+
+    def test_optional_section_and_page_default_to_none(self):
+        record = ChunkRecord(**self._valid_kwargs())
+        self.assertIsNone(record.section)
+        self.assertIsNone(record.page)
+
+    def test_section_and_page_can_be_set(self):
+        kwargs = self._valid_kwargs()
+        kwargs["section"] = "Background"
+        kwargs["page"] = 7
+        record = ChunkRecord(**kwargs)
+        self.assertEqual(record.section, "Background")
+        self.assertEqual(record.page, 7)
+
+
+# ---------------------------------------------------------------------------
+# build_snippet helper tests
+# ---------------------------------------------------------------------------
+
+class TestBuildSnippet(unittest.TestCase):
+
+    def test_short_text_returned_unchanged(self):
+        text = "Short text."
+        self.assertEqual(build_snippet(text), text)
+
+    def test_exactly_200_chars_returned_unchanged(self):
+        text = "x" * 200
+        self.assertEqual(build_snippet(text), text)
+
+    def test_201_chars_truncated_with_ellipsis(self):
+        text = "x" * 201
+        result = build_snippet(text)
+        self.assertEqual(result, "x" * 200 + "...")
+        self.assertEqual(len(result), 203)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_cli_build.py
+++ b/tests/test_cli_build.py
@@ -1,0 +1,467 @@
+"""
+Stage 3 CLI tests: nn-pipeline build command.
+
+Tests in this file validate:
+- test_cli_build_smoke            — pipeline runs end-to-end, three artifacts created
+- test_cli_deterministic_output   — identical inputs produce identical artifact bytes
+
+All tests call run_pipeline() directly (no subprocess) so they are fast,
+isolated, and independent of shell PATH configuration.
+"""
+
+import hashlib
+import json
+import sys
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from cli.build_ragpack import (
+    PipelineResult,
+    _collect_source_files,
+    _compute_source_hash,
+    _compute_source_id,
+    run_pipeline,
+)
+from ragpack.manifest_builder import REQUIRED_MANIFEST_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_CREATION_TIME = "2026-03-07T00:00:00"
+
+_DOC_A = """\
+Artificial intelligence is transforming every industry.
+Machine learning models learn from data to make predictions.
+Natural language processing enables computers to understand human text.
+Deep learning uses many-layered neural networks for complex tasks.
+"""
+
+_DOC_B = """\
+The retrieval-augmented generation pattern combines search with generation.
+A vector store indexes embeddings of document chunks for similarity lookup.
+At query time the nearest chunks are retrieved and injected into the prompt.
+This grounds the model response in verifiable source material.
+"""
+
+
+def _make_input_dir(tmp: str, docs: dict | None = None) -> Path:
+    """
+    Create a temp input directory with synthetic .txt files.
+
+    Args:
+        tmp:  tempfile.TemporaryDirectory path string.
+        docs: Mapping of filename → content.  Defaults to two standard docs.
+    """
+    if docs is None:
+        docs = {"doc_a.txt": _DOC_A, "doc_b.txt": _DOC_B}
+    input_dir = Path(tmp) / "input"
+    input_dir.mkdir()
+    for name, content in docs.items():
+        (input_dir / name).write_text(content, encoding="utf-8")
+    return input_dir
+
+
+def _run(input_dir: Path, output_dir: Path, **kwargs) -> PipelineResult:
+    """Run pipeline with test defaults."""
+    defaults = dict(
+        chunk_size=40,
+        overlap=5,
+        creation_time=_CREATION_TIME,
+    )
+    defaults.update(kwargs)
+    return run_pipeline(input_dir=input_dir, output_dir=output_dir, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# _collect_source_files unit tests
+# ---------------------------------------------------------------------------
+
+class TestCollectSourceFiles(unittest.TestCase):
+    """_collect_source_files must return a stable sorted list."""
+
+    def test_returns_sorted_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            for name in ["z_last.txt", "a_first.txt", "m_middle.md"]:
+                (d / name).write_text("x")
+            files = _collect_source_files(d)
+        names = [f.name for f in files]
+        self.assertEqual(names, sorted(names))
+
+    def test_filters_unsupported_extensions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / "keep.txt").write_text("x")
+            (d / "keep.md").write_text("x")
+            (d / "skip.py").write_text("x")
+            (d / "skip.pdf").write_text("x")
+            files = _collect_source_files(d)
+        names = {f.name for f in files}
+        self.assertIn("keep.txt",  names)
+        self.assertIn("keep.md",   names)
+        self.assertNotIn("skip.py",  names)
+        self.assertNotIn("skip.pdf", names)
+
+    def test_excludes_hidden_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            (d / ".hidden.txt").write_text("x")
+            (d / "visible.txt").write_text("x")
+            files = _collect_source_files(d)
+        names = {f.name for f in files}
+        self.assertNotIn(".hidden.txt", names)
+        self.assertIn("visible.txt",    names)
+
+    def test_missing_dir_exits(self):
+        import typer
+        with self.assertRaises(typer.Exit):
+            _collect_source_files(Path("/nonexistent_dir_abc_xyz"))
+
+    def test_empty_dir_exits(self):
+        import typer
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(typer.Exit):
+                _collect_source_files(Path(tmp))
+
+    def test_two_calls_return_same_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            for name in ["b.txt", "a.txt", "c.md"]:
+                (d / name).write_text("x")
+            first  = [f.name for f in _collect_source_files(d)]
+            second = [f.name for f in _collect_source_files(d)]
+        self.assertEqual(first, second)
+
+
+# ---------------------------------------------------------------------------
+# Source hash / id helpers
+# ---------------------------------------------------------------------------
+
+class TestSourceHelpers(unittest.TestCase):
+
+    def test_source_hash_is_64_char_hex(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"hello world")
+            p = Path(f.name)
+        h = _compute_source_hash(p)
+        p.unlink()
+        self.assertEqual(len(h), 64)
+        self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_source_hash_matches_manual_sha256(self):
+        content = b"deterministic content"
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(content)
+            p = Path(f.name)
+        expected = hashlib.sha256(content).hexdigest()
+        actual = _compute_source_hash(p)
+        p.unlink()
+        self.assertEqual(actual, expected)
+
+    def test_source_id_stable_for_same_inputs(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"content")
+            p = Path(f.name)
+        h = _compute_source_hash(p)
+        id_a = _compute_source_id(p, h)
+        id_b = _compute_source_id(p, h)
+        p.unlink()
+        self.assertEqual(id_a, id_b)
+
+    def test_source_id_changes_when_content_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "doc.txt"
+            p.write_bytes(b"version one")
+            h1 = _compute_source_hash(p)
+            id1 = _compute_source_id(p, h1)
+            p.write_bytes(b"version two")
+            h2 = _compute_source_hash(p)
+            id2 = _compute_source_id(p, h2)
+        self.assertNotEqual(id1, id2)
+
+
+# ---------------------------------------------------------------------------
+# test_cli_build_smoke
+# ---------------------------------------------------------------------------
+
+class TestCliBuildSmoke(unittest.TestCase):
+    """
+    End-to-end smoke test: pipeline runs without error and produces the
+    three required artifacts with correct structure.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._input_dir  = _make_input_dir(self._tmp.name)
+        self._output_dir = Path(self._tmp.name) / "ragpack"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _result(self) -> PipelineResult:
+        return _run(self._input_dir, self._output_dir)
+
+    def test_returns_pipeline_result(self):
+        self.assertIsInstance(self._result(), PipelineResult)
+
+    def test_three_artifact_files_exist(self):
+        result = self._result()
+        self.assertTrue(result.written_paths["embeddings"].exists())
+        self.assertTrue(result.written_paths["chunks"].exists())
+        self.assertTrue(result.written_paths["manifest"].exists())
+
+    def test_artifact_filenames_correct(self):
+        result = self._result()
+        self.assertEqual(result.written_paths["embeddings"].name, "embeddings.npy")
+        self.assertEqual(result.written_paths["chunks"].name,     "chunks.parquet")
+        self.assertEqual(result.written_paths["manifest"].name,   "manifest.json")
+
+    def test_manifest_contains_required_fields(self):
+        result   = self._result()
+        manifest = json.loads(result.written_paths["manifest"].read_text(encoding="utf-8"))
+        for field in REQUIRED_MANIFEST_FIELDS:
+            self.assertIn(field, manifest, f"Required field '{field}' missing")
+
+    def test_manifest_chunk_count_positive(self):
+        result   = self._result()
+        manifest = json.loads(result.written_paths["manifest"].read_text(encoding="utf-8"))
+        self.assertGreater(manifest["chunk_count"], 0)
+
+    def test_manifest_chunk_count_matches_result(self):
+        result   = self._result()
+        manifest = json.loads(result.written_paths["manifest"].read_text(encoding="utf-8"))
+        self.assertEqual(manifest["chunk_count"], result.chunk_count)
+
+    def test_manifest_creation_time_matches_input(self):
+        result   = self._result()
+        manifest = json.loads(result.written_paths["manifest"].read_text(encoding="utf-8"))
+        self.assertEqual(manifest["creation_time"], _CREATION_TIME)
+
+    def test_embeddings_npy_loads_as_float32_array(self):
+        result     = self._result()
+        embeddings = np.load(str(result.written_paths["embeddings"]))
+        self.assertEqual(embeddings.ndim, 2)
+        self.assertEqual(embeddings.dtype, np.float32)
+
+    def test_embeddings_row_count_matches_chunk_count(self):
+        result     = self._result()
+        embeddings = np.load(str(result.written_paths["embeddings"]))
+        manifest   = json.loads(result.written_paths["manifest"].read_text(encoding="utf-8"))
+        self.assertEqual(embeddings.shape[0], manifest["chunk_count"])
+
+    def test_chunks_parquet_row_count_matches_chunk_count(self):
+        result = self._result()
+        table  = pq.read_table(str(result.written_paths["chunks"]))
+        self.assertEqual(table.num_rows, result.chunk_count)
+
+    def test_chunks_parquet_required_columns_present(self):
+        result = self._result()
+        table  = pq.read_table(str(result.written_paths["chunks"]))
+        for col in ["chunk_id", "source_id", "source_path", "source_hash",
+                    "chunk_index", "char_start", "char_end", "token_count",
+                    "text_snippet", "chunk_text_hash", "chunking_config_hash"]:
+            self.assertIn(col, table.schema.names,
+                          f"Required column '{col}' missing from chunks.parquet")
+
+    def test_file_count_matches_input_files(self):
+        result = self._result()
+        self.assertEqual(result.file_count, 2)
+
+    def test_source_files_list_is_sorted(self):
+        result = self._result()
+        names  = [f.name for f in result.source_files]
+        self.assertEqual(names, sorted(names))
+
+    def test_no_nan_or_inf_in_embeddings(self):
+        result     = self._result()
+        embeddings = np.load(str(result.written_paths["embeddings"]))
+        self.assertTrue(np.all(np.isfinite(embeddings)),
+                        "Embedding array contains NaN or Inf")
+
+    def test_output_dir_created_automatically(self):
+        deep_output = Path(self._tmp.name) / "nested" / "deep" / "ragpack"
+        self.assertFalse(deep_output.exists())
+        _run(self._input_dir, deep_output)
+        self.assertTrue(deep_output.is_dir())
+
+    def test_single_file_input_works(self):
+        """A single-file input directory must produce a valid pack."""
+        with tempfile.TemporaryDirectory() as tmp:
+            single_dir = Path(tmp) / "single"
+            single_dir.mkdir()
+            (single_dir / "only.txt").write_text(_DOC_A, encoding="utf-8")
+            out_dir = Path(tmp) / "out"
+            result = _run(single_dir, out_dir)
+        self.assertGreater(result.chunk_count, 0)
+        self.assertEqual(result.file_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# test_cli_deterministic_output
+# ---------------------------------------------------------------------------
+
+class TestCliDeterministicOutput(unittest.TestCase):
+    """
+    Two pipeline runs with identical inputs must produce byte-identical
+    artifacts on disk.
+    """
+
+    def test_embeddings_npy_identical_across_two_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = _make_input_dir(tmp)
+            out_a = Path(tmp) / "out_a"
+            out_b = Path(tmp) / "out_b"
+            _run(input_dir, out_a)
+            _run(input_dir, out_b)
+            bytes_a = (out_a / "embeddings.npy").read_bytes()
+            bytes_b = (out_b / "embeddings.npy").read_bytes()
+        self.assertEqual(bytes_a, bytes_b,
+                         "embeddings.npy bytes differ between two runs")
+
+    def test_manifest_json_identical_across_two_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = _make_input_dir(tmp)
+            out_a = Path(tmp) / "out_a"
+            out_b = Path(tmp) / "out_b"
+            _run(input_dir, out_a)
+            _run(input_dir, out_b)
+            text_a = (out_a / "manifest.json").read_text(encoding="utf-8")
+            text_b = (out_b / "manifest.json").read_text(encoding="utf-8")
+        self.assertEqual(text_a, text_b,
+                         "manifest.json content differs between two runs")
+
+    def test_chunks_parquet_identical_across_two_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = _make_input_dir(tmp)
+            out_a = Path(tmp) / "out_a"
+            out_b = Path(tmp) / "out_b"
+            _run(input_dir, out_a)
+            _run(input_dir, out_b)
+            bytes_a = (out_a / "chunks.parquet").read_bytes()
+            bytes_b = (out_b / "chunks.parquet").read_bytes()
+        self.assertEqual(bytes_a, bytes_b,
+                         "chunks.parquet bytes differ between two runs")
+
+    def test_different_creation_times_produce_different_manifests(self):
+        """creation_time must propagate into the manifest; different times differ."""
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = _make_input_dir(tmp)
+            out_a = Path(tmp) / "out_a"
+            out_b = Path(tmp) / "out_b"
+            _run(input_dir, out_a, creation_time="2026-01-01T00:00:00")
+            _run(input_dir, out_b, creation_time="2026-06-01T00:00:00")
+            m_a = json.loads((out_a / "manifest.json").read_text())
+            m_b = json.loads((out_b / "manifest.json").read_text())
+        self.assertNotEqual(m_a["manifest_hash"], m_b["manifest_hash"])
+
+    def test_chunk_ids_identical_across_two_runs(self):
+        """chunk_ids in the parquet must be identical between two runs."""
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = _make_input_dir(tmp)
+            out_a = Path(tmp) / "out_a"
+            out_b = Path(tmp) / "out_b"
+            _run(input_dir, out_a)
+            _run(input_dir, out_b)
+            ids_a = pq.read_table(str(out_a / "chunks.parquet")).column("chunk_id").to_pylist()
+            ids_b = pq.read_table(str(out_b / "chunks.parquet")).column("chunk_id").to_pylist()
+        self.assertEqual(ids_a, ids_b,
+                         "chunk_id columns differ between two runs")
+
+    def test_adding_file_changes_output(self):
+        """Adding a file must change the manifest hash — new content ≠ same pack."""
+        with tempfile.TemporaryDirectory() as tmp:
+            input_a = _make_input_dir(tmp, {"doc_a.txt": _DOC_A})
+
+            input_ab = Path(tmp) / "input_ab"
+            input_ab.mkdir()
+            (input_ab / "doc_a.txt").write_text(_DOC_A, encoding="utf-8")
+            (input_ab / "doc_b.txt").write_text(_DOC_B, encoding="utf-8")
+
+            out_a  = Path(tmp) / "out_a"
+            out_ab = Path(tmp) / "out_ab"
+            _run(input_a,  out_a)
+            _run(input_ab, out_ab)
+            m_a  = json.loads((out_a  / "manifest.json").read_text())
+            m_ab = json.loads((out_ab / "manifest.json").read_text())
+        self.assertNotEqual(m_a["manifest_hash"], m_ab["manifest_hash"])
+
+    def test_file_order_independent_of_creation_order(self):
+        """
+        Chunk IDs must be identical whether files are created in a-b or b-a
+        order, because sorting is by name, not creation timestamp.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            # First run: create a then b
+            in1 = Path(tmp) / "in1"
+            in1.mkdir()
+            (in1 / "alpha.txt").write_text(_DOC_A, encoding="utf-8")
+            (in1 / "beta.txt").write_text(_DOC_B, encoding="utf-8")
+
+            # Second run: create b then a
+            in2 = Path(tmp) / "in2"
+            in2.mkdir()
+            (in2 / "beta.txt").write_text(_DOC_B, encoding="utf-8")
+            (in2 / "alpha.txt").write_text(_DOC_A, encoding="utf-8")
+
+            out1 = Path(tmp) / "out1"
+            out2 = Path(tmp) / "out2"
+            _run(in1, out1)
+            _run(in2, out2)
+
+            ids1 = pq.read_table(str(out1 / "chunks.parquet")).column("chunk_id").to_pylist()
+            ids2 = pq.read_table(str(out2 / "chunks.parquet")).column("chunk_id").to_pylist()
+
+        self.assertEqual(ids1, ids2,
+                         "chunk_ids differ when files are created in different order")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline guard tests
+# ---------------------------------------------------------------------------
+
+class TestPipelineGuards(unittest.TestCase):
+
+    def test_missing_input_dir_exits(self):
+        import typer
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(typer.Exit):
+                run_pipeline(
+                    input_dir=Path("/does_not_exist_xyz"),
+                    output_dir=Path(tmp) / "out",
+                    chunk_size=40,
+                    overlap=5,
+                    creation_time=_CREATION_TIME,
+                )
+
+    def test_overlap_gte_chunk_size_raises(self):
+        """overlap >= chunk_size must be caught before the pipeline runs."""
+        import typer
+        with tempfile.TemporaryDirectory() as tmp:
+            input_dir = _make_input_dir(tmp)
+            out_dir   = Path(tmp) / "out"
+            raised = False
+            try:
+                run_pipeline(
+                    input_dir=input_dir,
+                    output_dir=out_dir,
+                    chunk_size=10,
+                    overlap=10,          # equal — must fail
+                    creation_time=_CREATION_TIME,
+                )
+            except (ValueError, typer.Exit, SystemExit):
+                raised = True
+            self.assertTrue(raised, "Expected error when overlap >= chunk_size")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_deterministic_embedder.py
+++ b/tests/test_deterministic_embedder.py
@@ -1,0 +1,464 @@
+"""
+Stage 2 contract tests: deterministic embedding generation.
+
+Tests in this file validate the EPIC3 Stage 2 deliverables:
+- test_embedding_repeatability        — same inputs → byte-identical float32 arrays
+- test_embedding_dimension_consistent — every row has the declared dimension
+- test_embedding_order_matches_chunks — output rows align with input chunk order
+"""
+
+import sys
+import os
+import unittest
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chunker import TokenChunker
+from embedder import DeterministicEmbedder, EmbedderMetadata
+from embedder.deterministic_embedder import EmbeddingResult, DEFAULT_MODEL_NAME
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SOURCE_ID   = "src-stage2-test"
+_SOURCE_PATH = "tests/fixtures/sample.txt"
+_SOURCE_HASH = "b" * 64
+
+_TEXT = (
+    "Artificial intelligence is transforming every industry. "
+    "Machine learning models learn from data to make predictions. "
+    "Natural language processing enables computers to understand human text. "
+    "Deep learning uses many-layered neural networks for complex tasks. "
+) * 3
+
+
+def _make_records(text: str = _TEXT, chunk_size: int = 40, overlap: int = 5):
+    """Return a list of ChunkRecord objects using standard test config."""
+    chunker = TokenChunker(
+        chunk_size=chunk_size,
+        overlap=overlap,
+        preserve_sentences=False,
+    )
+    return chunker.chunk_document(
+        text=text,
+        source_id=_SOURCE_ID,
+        source_path=_SOURCE_PATH,
+        source_hash=_SOURCE_HASH,
+    )
+
+
+# One shared embedder instance reused across tests to avoid loading the model
+# multiple times per test run.  It is created lazily so import-time errors
+# are surfaced clearly.
+_SHARED_EMBEDDER: DeterministicEmbedder | None = None
+
+
+def _get_embedder() -> DeterministicEmbedder:
+    global _SHARED_EMBEDDER
+    if _SHARED_EMBEDDER is None:
+        _SHARED_EMBEDDER = DeterministicEmbedder(DEFAULT_MODEL_NAME)
+    return _SHARED_EMBEDDER
+
+
+# ---------------------------------------------------------------------------
+# EmbedderMetadata unit tests
+# ---------------------------------------------------------------------------
+
+class TestEmbedderMetadata(unittest.TestCase):
+    """EmbedderMetadata must carry all required fields and serialise correctly."""
+
+    def _meta(self) -> EmbedderMetadata:
+        return _get_embedder().metadata
+
+    def test_embedding_model_is_non_empty_string(self):
+        self.assertIsInstance(self._meta().embedding_model, str)
+        self.assertGreater(len(self._meta().embedding_model), 0)
+
+    def test_embedding_version_is_non_empty_string(self):
+        self.assertIsInstance(self._meta().embedding_version, str)
+        self.assertGreater(len(self._meta().embedding_version), 0)
+
+    def test_embedding_dimension_is_positive_int(self):
+        dim = self._meta().embedding_dimension
+        self.assertIsInstance(dim, int)
+        self.assertGreater(dim, 0)
+
+    def test_model_hash_is_64_char_hex(self):
+        h = self._meta().model_hash
+        self.assertEqual(len(h), 64)
+        self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_dtype_is_float32(self):
+        self.assertEqual(self._meta().dtype, "float32")
+
+    def test_to_dict_contains_required_manifest_keys(self):
+        d = self._meta().to_dict()
+        required = {
+            "embedding_model",
+            "embedding_version",
+            "embedding_dimension",
+            "model_hash",
+            "dtype",
+        }
+        for key in required:
+            self.assertIn(key, d, f"Missing key '{key}' in EmbedderMetadata.to_dict()")
+
+    def test_to_dict_contains_legacy_keys_for_pack_writer(self):
+        """Legacy keys must be present so existing PackWriter stays compatible."""
+        d = self._meta().to_dict()
+        for legacy_key in ("name", "version", "dimensions"):
+            self.assertIn(legacy_key, d, f"Missing legacy key '{legacy_key}'")
+
+    def test_metadata_is_immutable(self):
+        """EmbedderMetadata is a frozen dataclass; normal attribute assignment must raise."""
+        meta = self._meta()
+        raised = False
+        try:
+            # Use the normal assignment path that frozen dataclasses block.
+            # object.__setattr__ is an internal bypass and must not be used here.
+            setattr(meta, "embedding_model", "should-fail")
+        except (AttributeError, TypeError):
+            raised = True
+        self.assertTrue(raised, "Expected frozen dataclass to reject attribute mutation")
+
+    def test_model_hash_stable_across_instances(self):
+        """Two embedders with the same model must produce the same model_hash."""
+        embedder_a = DeterministicEmbedder(DEFAULT_MODEL_NAME)
+        embedder_b = DeterministicEmbedder(DEFAULT_MODEL_NAME)
+        self.assertEqual(embedder_a.metadata.model_hash, embedder_b.metadata.model_hash)
+
+
+# ---------------------------------------------------------------------------
+# test_embedding_repeatability
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingRepeatability(unittest.TestCase):
+    """
+    Embedding the same chunks twice must produce byte-identical float32 arrays.
+    """
+
+    def test_two_calls_produce_identical_arrays(self):
+        """Core repeatability requirement: same input → same output."""
+        embedder = _get_embedder()
+        records = _make_records()
+
+        result_a = embedder.embed_chunks(records)
+        result_b = embedder.embed_chunks(records)
+
+        np.testing.assert_array_equal(
+            result_a.embeddings,
+            result_b.embeddings,
+            err_msg="Embeddings differ between two calls with identical input",
+        )
+
+    def test_two_independent_embedder_instances_produce_identical_arrays(self):
+        """
+        A freshly constructed DeterministicEmbedder must produce the same
+        embeddings as a previously constructed one with the same model.
+        """
+        records = _make_records()
+
+        embedder_1 = DeterministicEmbedder(DEFAULT_MODEL_NAME)
+        embedder_2 = DeterministicEmbedder(DEFAULT_MODEL_NAME)
+
+        result_1 = embedder_1.embed_chunks(records)
+        result_2 = embedder_2.embed_chunks(records)
+
+        np.testing.assert_array_equal(
+            result_1.embeddings,
+            result_2.embeddings,
+            err_msg="Embeddings differ between two independent embedder instances",
+        )
+
+    def test_dtype_is_always_float32(self):
+        """Output array must always be float32 regardless of model internals."""
+        result = _get_embedder().embed_chunks(_make_records())
+        self.assertEqual(result.embeddings.dtype, np.float32)
+
+    def test_empty_chunk_list_returns_zero_row_array(self):
+        """embed_chunks([]) must return a valid (0, D) float32 array."""
+        result = _get_embedder().embed_chunks([])
+        self.assertEqual(result.embeddings.ndim, 2)
+        self.assertEqual(result.embeddings.shape[0], 0)
+        self.assertEqual(result.embeddings.shape[1], _get_embedder().metadata.embedding_dimension)
+        self.assertEqual(result.embeddings.dtype, np.float32)
+        self.assertEqual(result.chunk_ids, [])
+
+    def test_single_chunk_repeatable(self):
+        """A single-chunk input must be repeatable."""
+        records = _make_records(text="A single sentence for repeatability.")
+        self.assertGreaterEqual(len(records), 1)
+        single = records[:1]
+
+        result_a = _get_embedder().embed_chunks(single)
+        result_b = _get_embedder().embed_chunks(single)
+
+        np.testing.assert_array_equal(result_a.embeddings, result_b.embeddings)
+
+    def test_embed_texts_matches_embed_chunks_for_same_text(self):
+        """
+        embed_texts() called with the same snippet strings must produce
+        the same vectors as embed_chunks() for the same records.
+        """
+        embedder = _get_embedder()
+        records = _make_records()
+
+        chunk_result = embedder.embed_chunks(records)
+        texts = [r.text_snippet for r in records]
+        text_result = embedder.embed_texts(texts)
+
+        np.testing.assert_array_equal(
+            chunk_result.embeddings,
+            text_result,
+            err_msg="embed_chunks and embed_texts produced different vectors for the same text",
+        )
+
+    def test_different_texts_produce_different_embeddings(self):
+        """Sanity check: semantically different sentences must not be identical."""
+        embedder = _get_embedder()
+        arr = embedder.embed_texts([
+            "The sky is blue.",
+            "Quantum mechanics describes subatomic particles.",
+        ])
+        self.assertFalse(
+            np.array_equal(arr[0], arr[1]),
+            "Different texts produced identical embedding vectors",
+        )
+
+
+# ---------------------------------------------------------------------------
+# test_embedding_dimension_consistent
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingDimensionConsistent(unittest.TestCase):
+    """
+    Every embedding row must have exactly the declared dimension D.
+    The declared dimension must match the model's reported dimension.
+    """
+
+    def test_embedding_shape_is_n_by_d(self):
+        """Output shape must be (N, D) where N = len(chunks) and D = declared dim."""
+        embedder = _get_embedder()
+        records = _make_records()
+        result = embedder.embed_chunks(records)
+
+        expected_d = embedder.metadata.embedding_dimension
+        self.assertEqual(result.embeddings.ndim, 2)
+        self.assertEqual(result.embeddings.shape[0], len(records))
+        self.assertEqual(result.embeddings.shape[1], expected_d)
+
+    def test_dimension_matches_metadata(self):
+        """Actual column count must equal metadata.embedding_dimension."""
+        embedder = _get_embedder()
+        result = embedder.embed_chunks(_make_records())
+        self.assertEqual(
+            result.embeddings.shape[1],
+            result.metadata.embedding_dimension,
+        )
+
+    def test_dimension_consistent_across_variable_length_inputs(self):
+        """D must be the same whether we embed 1 or many chunks."""
+        embedder = _get_embedder()
+        declared_dim = embedder.metadata.embedding_dimension
+
+        for n_chunks in (1, 3, 7):
+            records = _make_records()[:n_chunks] if len(_make_records()) >= n_chunks else _make_records()
+            result = embedder.embed_chunks(records)
+            self.assertEqual(
+                result.embeddings.shape[1],
+                declared_dim,
+                f"Dimension mismatch for input size {n_chunks}",
+            )
+
+    def test_all_miniLM_dimension_is_384(self):
+        """all-MiniLM-L6-v2 must always produce 384-dimensional vectors."""
+        self.assertEqual(_get_embedder().metadata.embedding_dimension, 384)
+
+    def test_no_nan_or_inf_in_embeddings(self):
+        """Embedding values must all be finite."""
+        result = _get_embedder().embed_chunks(_make_records())
+        self.assertTrue(
+            np.all(np.isfinite(result.embeddings)),
+            "Embedding array contains NaN or Inf values",
+        )
+
+    def test_embed_texts_returns_correct_shape(self):
+        """embed_texts must also return (N, D) with the correct D."""
+        embedder = _get_embedder()
+        texts = ["First sentence.", "Second sentence.", "Third sentence."]
+        arr = embedder.embed_texts(texts)
+        self.assertEqual(arr.shape, (3, embedder.metadata.embedding_dimension))
+        self.assertEqual(arr.dtype, np.float32)
+
+    def test_embed_texts_empty_returns_zero_row_array(self):
+        embedder = _get_embedder()
+        arr = embedder.embed_texts([])
+        self.assertEqual(arr.shape, (0, embedder.metadata.embedding_dimension))
+        self.assertEqual(arr.dtype, np.float32)
+
+    def test_result_metadata_dimension_equals_embedder_metadata(self):
+        """EmbeddingResult.metadata must be the same object as embedder.metadata."""
+        embedder = _get_embedder()
+        result = embedder.embed_chunks(_make_records())
+        self.assertIs(result.metadata, embedder.metadata)
+
+
+# ---------------------------------------------------------------------------
+# test_embedding_order_matches_chunks
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingOrderMatchesChunks(unittest.TestCase):
+    """
+    Row i in the embedding array must correspond to chunk i in the input list.
+    The chunk_ids list in EmbeddingResult must be aligned in the same order.
+    """
+
+    def test_chunk_ids_align_with_input_order(self):
+        """chunk_ids in result must match the order of the input records."""
+        embedder = _get_embedder()
+        records = _make_records()
+        result = embedder.embed_chunks(records)
+
+        self.assertEqual(len(result.chunk_ids), len(records))
+        for idx, (chunk_id, record) in enumerate(zip(result.chunk_ids, records)):
+            self.assertEqual(
+                chunk_id,
+                record.chunk_id,
+                f"chunk_ids[{idx}] does not match records[{idx}].chunk_id",
+            )
+
+    def test_row_count_equals_chunk_count(self):
+        """Number of embedding rows must equal number of input chunks."""
+        embedder = _get_embedder()
+        records = _make_records()
+        result = embedder.embed_chunks(records)
+        self.assertEqual(result.embeddings.shape[0], len(records))
+
+    def test_reversed_input_produces_reversed_output(self):
+        """
+        If the input order is reversed, the embedding rows must be reversed.
+        This validates strict positional alignment.
+        """
+        embedder = _get_embedder()
+        records = _make_records()
+        self.assertGreater(len(records), 1, "Need at least 2 chunks for this test")
+
+        result_fwd = embedder.embed_chunks(records)
+        result_rev = embedder.embed_chunks(list(reversed(records)))
+
+        # Row i of result_rev should equal row (N-1-i) of result_fwd
+        n = len(records)
+        for i in range(n):
+            np.testing.assert_array_equal(
+                result_rev.embeddings[i],
+                result_fwd.embeddings[n - 1 - i],
+                err_msg=f"Row {i} of reversed result does not match row {n-1-i} of forward result",
+            )
+
+    def test_chunk_ids_reversed_when_input_reversed(self):
+        """chunk_ids in result must also reverse when input order reverses."""
+        embedder = _get_embedder()
+        records = _make_records()
+        self.assertGreater(len(records), 1)
+
+        result_fwd = embedder.embed_chunks(records)
+        result_rev = embedder.embed_chunks(list(reversed(records)))
+
+        self.assertEqual(result_fwd.chunk_ids, list(reversed(result_rev.chunk_ids)))
+
+    def test_subset_embedding_matches_corresponding_rows_of_full_embedding(self):
+        """
+        Embedding a subset of chunks must produce vectors close to the
+        corresponding rows extracted from embedding the full list.
+
+        Note on tolerance: transformer models are not strictly associative
+        across different batch sizes — float32 accumulation order changes
+        with batch padding, producing differences up to ~1e-6 in practice.
+        We use allclose(atol=1e-5) which is tight enough to detect real
+        ordering bugs while accepting unavoidable float32 rounding.
+        The key guarantee tested here is ordering, not bitwise identity
+        across batch compositions.
+        """
+        embedder = _get_embedder()
+        records = _make_records()
+        self.assertGreater(len(records), 2, "Need at least 3 chunks for this test")
+
+        result_full = embedder.embed_chunks(records)
+
+        # Pick a contiguous subset
+        subset = records[1:3]
+        result_sub = embedder.embed_chunks(subset)
+
+        np.testing.assert_allclose(
+            result_sub.embeddings,
+            result_full.embeddings[1:3],
+            atol=1e-5,
+            rtol=0,
+            err_msg=(
+                "Subset embeddings deviate from corresponding full-batch rows "
+                "by more than the expected float32 tolerance (1e-5)"
+            ),
+        )
+
+    def test_embedding_result_invariants_hold(self):
+        """EmbeddingResult post-init must reject shape mismatches."""
+        meta = _get_embedder().metadata
+        dim = meta.embedding_dimension
+
+        # Wrong dtype
+        with self.assertRaises(ValueError):
+            EmbeddingResult(
+                embeddings=np.zeros((2, dim), dtype=np.float64),
+                metadata=meta,
+                chunk_ids=["a", "b"],
+            )
+
+        # Row count / chunk_ids length mismatch
+        with self.assertRaises(ValueError):
+            EmbeddingResult(
+                embeddings=np.zeros((2, dim), dtype=np.float32),
+                metadata=meta,
+                chunk_ids=["only-one"],
+            )
+
+        # Wrong column count
+        with self.assertRaises(ValueError):
+            EmbeddingResult(
+                embeddings=np.zeros((2, dim + 1), dtype=np.float32),
+                metadata=meta,
+                chunk_ids=["a", "b"],
+            )
+
+
+# ---------------------------------------------------------------------------
+# DeterministicEmbedder construction guard tests
+# ---------------------------------------------------------------------------
+
+class TestDeterministicEmbedderConstruction(unittest.TestCase):
+
+    def test_empty_model_name_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            DeterministicEmbedder("")
+
+    def test_whitespace_model_name_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            DeterministicEmbedder("   ")
+
+    def test_invalid_model_name_raises_runtime_error(self):
+        with self.assertRaises(RuntimeError):
+            DeterministicEmbedder("this-model-does-not-exist-at-all-xyz-abc-999")
+
+    def test_non_chunk_record_raises_type_error(self):
+        """embed_chunks must reject non-ChunkRecord inputs."""
+        embedder = _get_embedder()
+        with self.assertRaises(TypeError):
+            embedder.embed_chunks(["not a ChunkRecord"])  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_ragpack_builder.py
+++ b/tests/test_ragpack_builder.py
@@ -1,0 +1,560 @@
+"""
+Stage 3 contract tests: RAGPack builder, writer, and manifest.
+
+Tests in this file validate the EPIC3 Stage 3 deliverables:
+- test_ragpack_repeatability       — two builds with same inputs → identical files
+- test_manifest_complete           — manifest contains every required field
+- test_embedding_chunk_alignment   — embeddings rows align with chunk order
+- test_ragpack_roundtrip           — write to disk → read back → assert fidelity
+"""
+
+import json
+import sys
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from chunker import TokenChunker
+from embedder import DeterministicEmbedder
+from embedder.deterministic_embedder import DEFAULT_MODEL_NAME
+from ragpack import ManifestBuilder, Ragpack, RagpackBuilder, RagpackWriter
+from ragpack.manifest_builder import REQUIRED_MANIFEST_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SOURCE_ID   = "src-stage3-test"
+_SOURCE_PATH = "tests/fixtures/sample.txt"
+_SOURCE_HASH = "c" * 64
+_CREATION_TIME = "2026-03-06T00:00:00"
+
+_TEXT = (
+    "Artificial intelligence is transforming every industry. "
+    "Machine learning models learn from data to make predictions. "
+    "Natural language processing enables computers to understand human text. "
+    "Deep learning uses many-layered neural networks for complex tasks. "
+) * 3
+
+
+def _make_records(text: str = _TEXT, chunk_size: int = 40, overlap: int = 5):
+    chunker = TokenChunker(
+        chunk_size=chunk_size,
+        overlap=overlap,
+        preserve_sentences=False,
+    )
+    return chunker.chunk_document(
+        text=text,
+        source_id=_SOURCE_ID,
+        source_path=_SOURCE_PATH,
+        source_hash=_SOURCE_HASH,
+    )
+
+
+# One shared embedder to avoid loading the model on every test.
+_EMBEDDER: DeterministicEmbedder | None = None
+
+
+def _get_embedder() -> DeterministicEmbedder:
+    global _EMBEDDER
+    if _EMBEDDER is None:
+        _EMBEDDER = DeterministicEmbedder(DEFAULT_MODEL_NAME)
+    return _EMBEDDER
+
+
+def _build_ragpack(records=None) -> Ragpack:
+    if records is None:
+        records = _make_records()
+    builder = RagpackBuilder(_get_embedder())
+    return builder.build(chunks=records, creation_time=_CREATION_TIME)
+
+
+# ---------------------------------------------------------------------------
+# ManifestBuilder unit tests
+# ---------------------------------------------------------------------------
+
+class TestManifestBuilder(unittest.TestCase):
+
+    def _make_builder(self, **overrides) -> ManifestBuilder:
+        kwargs = dict(
+            chunk_count=10,
+            embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+            embedding_dimension=384,
+            model_hash="a" * 64,
+            chunking_config_hash="b" * 64,
+            dtype="float32",
+            creation_time=_CREATION_TIME,
+            embedding_version="3.4.1",
+        )
+        kwargs.update(overrides)
+        return ManifestBuilder(**kwargs)
+
+    def test_build_returns_dict(self):
+        self.assertIsInstance(self._make_builder().build(), dict)
+
+    def test_all_required_fields_present(self):
+        manifest = self._make_builder().build()
+        for field in REQUIRED_MANIFEST_FIELDS:
+            self.assertIn(field, manifest, f"Required field '{field}' missing from manifest")
+
+    def test_chunk_count_stored_correctly(self):
+        manifest = self._make_builder(chunk_count=42).build()
+        self.assertEqual(manifest["chunk_count"], 42)
+
+    def test_embedding_model_stored_correctly(self):
+        manifest = self._make_builder().build()
+        self.assertEqual(manifest["embedding_model"],
+                         "sentence-transformers/all-MiniLM-L6-v2")
+
+    def test_embedding_dimension_stored_correctly(self):
+        manifest = self._make_builder().build()
+        self.assertEqual(manifest["embedding_dimension"], 384)
+
+    def test_model_hash_stored_correctly(self):
+        manifest = self._make_builder().build()
+        self.assertEqual(manifest["model_hash"], "a" * 64)
+
+    def test_chunking_config_hash_stored_correctly(self):
+        manifest = self._make_builder().build()
+        self.assertEqual(manifest["chunking_config_hash"], "b" * 64)
+
+    def test_dtype_stored_correctly(self):
+        manifest = self._make_builder().build()
+        self.assertEqual(manifest["dtype"], "float32")
+
+    def test_creation_time_stored_correctly(self):
+        manifest = self._make_builder().build()
+        self.assertEqual(manifest["creation_time"], _CREATION_TIME)
+
+    def test_manifest_hash_is_present_and_64_char_hex(self):
+        manifest = self._make_builder().build()
+        self.assertIn("manifest_hash", manifest)
+        h = manifest["manifest_hash"]
+        self.assertEqual(len(h), 64)
+        self.assertTrue(all(c in "0123456789abcdef" for c in h))
+
+    def test_manifest_hash_changes_when_chunk_count_changes(self):
+        m1 = self._make_builder(chunk_count=10).build()
+        m2 = self._make_builder(chunk_count=11).build()
+        self.assertNotEqual(m1["manifest_hash"], m2["manifest_hash"])
+
+    def test_same_inputs_produce_same_manifest_hash(self):
+        m1 = self._make_builder().build()
+        m2 = self._make_builder().build()
+        self.assertEqual(m1["manifest_hash"], m2["manifest_hash"])
+
+    def test_negative_chunk_count_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_builder(chunk_count=-1)
+
+    def test_empty_embedding_model_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_builder(embedding_model="")
+
+    def test_empty_creation_time_raises(self):
+        with self.assertRaises(ValueError):
+            self._make_builder(creation_time="")
+
+    def test_files_block_points_to_three_artifacts(self):
+        manifest = self._make_builder().build()
+        files = manifest["files"]
+        self.assertIn("embeddings", files)
+        self.assertIn("chunks", files)
+        self.assertIn("manifest", files)
+        self.assertEqual(files["embeddings"], "embeddings.npy")
+        self.assertEqual(files["chunks"],     "chunks.parquet")
+        self.assertEqual(files["manifest"],   "manifest.json")
+
+
+# ---------------------------------------------------------------------------
+# test_manifest_complete  (end-to-end, from RagpackBuilder output)
+# ---------------------------------------------------------------------------
+
+class TestManifestComplete(unittest.TestCase):
+    """Manifest produced by RagpackBuilder must contain all required fields."""
+
+    def test_manifest_contains_all_required_fields(self):
+        ragpack = _build_ragpack()
+        for field in REQUIRED_MANIFEST_FIELDS:
+            self.assertIn(field, ragpack.manifest,
+                          f"Required field '{field}' missing from ragpack.manifest")
+
+    def test_manifest_chunk_count_matches_actual_chunks(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        self.assertEqual(ragpack.manifest["chunk_count"], len(records))
+
+    def test_manifest_embedding_model_matches_embedder(self):
+        ragpack = _build_ragpack()
+        self.assertEqual(ragpack.manifest["embedding_model"],
+                         _get_embedder().metadata.embedding_model)
+
+    def test_manifest_embedding_dimension_matches_embedder(self):
+        ragpack = _build_ragpack()
+        self.assertEqual(ragpack.manifest["embedding_dimension"],
+                         _get_embedder().metadata.embedding_dimension)
+
+    def test_manifest_model_hash_matches_embedder(self):
+        ragpack = _build_ragpack()
+        self.assertEqual(ragpack.manifest["model_hash"],
+                         _get_embedder().metadata.model_hash)
+
+    def test_manifest_chunking_config_hash_matches_first_chunk(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        self.assertEqual(ragpack.manifest["chunking_config_hash"],
+                         records[0].chunking_config_hash)
+
+    def test_manifest_dtype_is_float32(self):
+        ragpack = _build_ragpack()
+        self.assertEqual(ragpack.manifest["dtype"], "float32")
+
+    def test_manifest_creation_time_matches_input(self):
+        ragpack = _build_ragpack()
+        self.assertEqual(ragpack.manifest["creation_time"], _CREATION_TIME)
+
+    def test_manifest_is_json_serialisable(self):
+        ragpack = _build_ragpack()
+        try:
+            json.dumps(ragpack.manifest)
+        except (TypeError, ValueError) as exc:
+            self.fail(f"manifest is not JSON-serialisable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# test_embedding_chunk_alignment
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingChunkAlignment(unittest.TestCase):
+    """Embedding row i must correspond to chunk i in every produced Ragpack."""
+
+    def test_row_count_equals_chunk_count(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        self.assertEqual(ragpack.embeddings.shape[0], len(records))
+
+    def test_chunk_ids_list_aligned_with_chunks(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        for idx, (cid, chunk) in enumerate(zip(ragpack.chunk_ids, ragpack.chunks)):
+            self.assertEqual(cid, chunk.chunk_id,
+                             f"chunk_ids[{idx}] does not match chunks[{idx}].chunk_id")
+
+    def test_embedding_shape_n_by_d(self):
+        ragpack = _build_ragpack()
+        d = _get_embedder().metadata.embedding_dimension
+        self.assertEqual(ragpack.embeddings.ndim, 2)
+        self.assertEqual(ragpack.embeddings.shape[1], d)
+
+    def test_embedding_dtype_is_float32(self):
+        ragpack = _build_ragpack()
+        self.assertEqual(ragpack.embeddings.dtype, np.float32)
+
+    def test_no_nan_or_inf_in_embeddings(self):
+        ragpack = _build_ragpack()
+        self.assertTrue(np.all(np.isfinite(ragpack.embeddings)),
+                        "Embedding array contains NaN or Inf")
+
+    def test_reversed_chunks_produce_reversed_embedding_rows(self):
+        records = _make_records()
+        self.assertGreater(len(records), 1)
+
+        builder = RagpackBuilder(_get_embedder())
+        pack_fwd = builder.build(chunks=records,              creation_time=_CREATION_TIME)
+        pack_rev = builder.build(chunks=list(reversed(records)), creation_time=_CREATION_TIME)
+
+        n = len(records)
+        for i in range(n):
+            np.testing.assert_array_equal(
+                pack_rev.embeddings[i],
+                pack_fwd.embeddings[n - 1 - i],
+                err_msg=f"Row {i} of reversed pack does not match row {n-1-i} of forward pack",
+            )
+
+    def test_chunk_records_unchanged_after_build(self):
+        """RagpackBuilder must not mutate the input ChunkRecord objects."""
+        records = _make_records()
+        original_ids = [r.chunk_id for r in records]
+        _build_ragpack(records)
+        after_ids = [r.chunk_id for r in records]
+        self.assertEqual(original_ids, after_ids)
+
+
+# ---------------------------------------------------------------------------
+# test_ragpack_repeatability
+# ---------------------------------------------------------------------------
+
+class TestRagpackRepeatability(unittest.TestCase):
+    """Two builds with identical inputs must produce byte-identical artifacts."""
+
+    def test_two_builds_produce_identical_embeddings(self):
+        records = _make_records()
+        builder = RagpackBuilder(_get_embedder())
+
+        pack_a = builder.build(chunks=records, creation_time=_CREATION_TIME)
+        pack_b = builder.build(chunks=records, creation_time=_CREATION_TIME)
+
+        np.testing.assert_array_equal(
+            pack_a.embeddings, pack_b.embeddings,
+            err_msg="Embeddings differ between two builds with identical input",
+        )
+
+    def test_two_builds_produce_identical_manifests(self):
+        records = _make_records()
+        builder = RagpackBuilder(_get_embedder())
+
+        pack_a = builder.build(chunks=records, creation_time=_CREATION_TIME)
+        pack_b = builder.build(chunks=records, creation_time=_CREATION_TIME)
+
+        self.assertEqual(pack_a.manifest, pack_b.manifest)
+
+    def test_two_builds_produce_identical_chunk_ids(self):
+        records = _make_records()
+        builder = RagpackBuilder(_get_embedder())
+
+        pack_a = builder.build(chunks=records, creation_time=_CREATION_TIME)
+        pack_b = builder.build(chunks=records, creation_time=_CREATION_TIME)
+
+        self.assertEqual(pack_a.chunk_ids, pack_b.chunk_ids)
+
+    def test_different_creation_times_produce_different_manifest_hashes(self):
+        """creation_time must influence the manifest hash."""
+        records = _make_records()
+        builder = RagpackBuilder(_get_embedder())
+
+        pack_a = builder.build(chunks=records, creation_time="2026-01-01T00:00:00")
+        pack_b = builder.build(chunks=records, creation_time="2026-06-01T00:00:00")
+
+        self.assertNotEqual(pack_a.manifest["manifest_hash"],
+                            pack_b.manifest["manifest_hash"])
+
+    def test_written_embeddings_npy_identical_across_two_writes(self):
+        """The embeddings.npy bytes must be identical for two writes of the same pack."""
+        ragpack = _build_ragpack()
+        writer = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dir_a = Path(tmp) / "pack_a"
+            dir_b = Path(tmp) / "pack_b"
+            writer.write(ragpack, dir_a)
+            writer.write(ragpack, dir_b)
+
+            bytes_a = (dir_a / "embeddings.npy").read_bytes()
+            bytes_b = (dir_b / "embeddings.npy").read_bytes()
+            self.assertEqual(bytes_a, bytes_b,
+                             "embeddings.npy bytes differ between two writes")
+
+    def test_written_manifest_json_identical_across_two_writes(self):
+        """manifest.json content must be identical for two writes of the same pack."""
+        ragpack = _build_ragpack()
+        writer = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dir_a = Path(tmp) / "pack_a"
+            dir_b = Path(tmp) / "pack_b"
+            writer.write(ragpack, dir_a)
+            writer.write(ragpack, dir_b)
+
+            text_a = (dir_a / "manifest.json").read_text(encoding="utf-8")
+            text_b = (dir_b / "manifest.json").read_text(encoding="utf-8")
+            self.assertEqual(text_a, text_b,
+                             "manifest.json content differs between two writes")
+
+    def test_written_chunks_parquet_identical_across_two_writes(self):
+        """chunks.parquet bytes must be identical for two writes of the same pack."""
+        ragpack = _build_ragpack()
+        writer = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dir_a = Path(tmp) / "pack_a"
+            dir_b = Path(tmp) / "pack_b"
+            writer.write(ragpack, dir_a)
+            writer.write(ragpack, dir_b)
+
+            bytes_a = (dir_a / "chunks.parquet").read_bytes()
+            bytes_b = (dir_b / "chunks.parquet").read_bytes()
+            self.assertEqual(bytes_a, bytes_b,
+                             "chunks.parquet bytes differ between two writes")
+
+
+# ---------------------------------------------------------------------------
+# test_ragpack_roundtrip
+# ---------------------------------------------------------------------------
+
+class TestRagpackRoundtrip(unittest.TestCase):
+    """Write to disk → read back → assert fidelity."""
+
+    def _write_and_read(self, ragpack: Ragpack) -> dict:
+        """Write pack to a temp dir and read all three artifacts back."""
+        writer = RagpackWriter()
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "ragpack"
+            paths = writer.write(ragpack, out_dir)
+
+            embeddings_back  = np.load(str(paths["embeddings"]))
+            manifest_back    = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+            chunks_table     = pq.read_table(str(paths["chunks"]))
+
+        return {
+            "embeddings": embeddings_back,
+            "manifest":   manifest_back,
+            "chunks_table": chunks_table,
+        }
+
+    def test_embeddings_npy_roundtrip(self):
+        ragpack = _build_ragpack()
+        result  = self._write_and_read(ragpack)
+        np.testing.assert_array_equal(ragpack.embeddings, result["embeddings"],
+                                      err_msg="embeddings.npy roundtrip mismatch")
+
+    def test_embeddings_dtype_preserved_after_roundtrip(self):
+        ragpack = _build_ragpack()
+        result  = self._write_and_read(ragpack)
+        self.assertEqual(result["embeddings"].dtype, np.float32)
+
+    def test_manifest_roundtrip(self):
+        ragpack = _build_ragpack()
+        result  = self._write_and_read(ragpack)
+        self.assertEqual(ragpack.manifest, result["manifest"])
+
+    def test_chunks_parquet_row_count(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        result  = self._write_and_read(ragpack)
+        self.assertEqual(result["chunks_table"].num_rows, len(records))
+
+    def test_chunks_parquet_chunk_id_column(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        result  = self._write_and_read(ragpack)
+        table   = result["chunks_table"]
+
+        expected_ids = [r.chunk_id for r in records]
+        actual_ids   = table.column("chunk_id").to_pylist()
+        self.assertEqual(actual_ids, expected_ids,
+                         "chunk_id column order differs after roundtrip")
+
+    def test_chunks_parquet_required_columns_present(self):
+        ragpack = _build_ragpack()
+        result  = self._write_and_read(ragpack)
+        table   = result["chunks_table"]
+
+        required_cols = [
+            "chunk_id", "source_id", "source_path", "source_hash",
+            "chunk_index", "char_start", "char_end", "token_count",
+            "text_snippet", "chunk_text_hash", "chunking_config_hash",
+        ]
+        for col in required_cols:
+            self.assertIn(col, table.schema.names,
+                          f"Required column '{col}' missing from chunks.parquet")
+
+    def test_chunks_parquet_source_path_preserved(self):
+        records = _make_records()
+        ragpack = _build_ragpack(records)
+        result  = self._write_and_read(ragpack)
+        table   = result["chunks_table"]
+
+        actual_paths = table.column("source_path").to_pylist()
+        for path_val in actual_paths:
+            self.assertEqual(path_val, _SOURCE_PATH)
+
+    def test_three_files_written(self):
+        ragpack = _build_ragpack()
+        writer  = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "ragpack"
+            paths   = writer.write(ragpack, out_dir)
+
+            self.assertIn("embeddings", paths)
+            self.assertIn("chunks",     paths)
+            self.assertIn("manifest",   paths)
+            self.assertTrue(paths["embeddings"].exists())
+            self.assertTrue(paths["chunks"].exists())
+            self.assertTrue(paths["manifest"].exists())
+
+    def test_output_filenames_match_manifest(self):
+        ragpack = _build_ragpack()
+        writer  = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "ragpack"
+            paths   = writer.write(ragpack, out_dir)
+            manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+
+        self.assertEqual(paths["embeddings"].name, manifest["files"]["embeddings"])
+        self.assertEqual(paths["chunks"].name,     manifest["files"]["chunks"])
+        self.assertEqual(paths["manifest"].name,   manifest["files"]["manifest"])
+
+
+# ---------------------------------------------------------------------------
+# RagpackBuilder construction guard tests
+# ---------------------------------------------------------------------------
+
+class TestRagpackBuilderGuards(unittest.TestCase):
+
+    def test_non_embedder_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            RagpackBuilder("not an embedder")  # type: ignore[arg-type]
+
+    def test_empty_creation_time_raises_value_error(self):
+        builder = RagpackBuilder(_get_embedder())
+        with self.assertRaises(ValueError):
+            builder.build(chunks=_make_records(), creation_time="")
+
+    def test_non_chunk_record_in_list_raises_type_error(self):
+        builder = RagpackBuilder(_get_embedder())
+        with self.assertRaises(TypeError):
+            builder.build(chunks=["not a record"], creation_time=_CREATION_TIME)  # type: ignore[arg-type]
+
+    def test_empty_chunks_builds_valid_ragpack(self):
+        """Empty chunk list is valid; manifest chunk_count must be 0."""
+        builder = RagpackBuilder(_get_embedder())
+        pack = builder.build(chunks=[], creation_time=_CREATION_TIME)
+        self.assertEqual(len(pack.chunks), 0)
+        self.assertEqual(pack.embeddings.shape[0], 0)
+        self.assertEqual(pack.manifest["chunk_count"], 0)
+
+
+# ---------------------------------------------------------------------------
+# RagpackWriter guard tests
+# ---------------------------------------------------------------------------
+
+class TestRagpackWriterGuards(unittest.TestCase):
+
+    def test_non_ragpack_raises_type_error(self):
+        writer = RagpackWriter()
+        with self.assertRaises(TypeError):
+            writer.write("not a ragpack", "/tmp/whatever")  # type: ignore[arg-type]
+
+    def test_output_dir_created_if_absent(self):
+        ragpack = _build_ragpack()
+        writer  = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "nested" / "new_dir"
+            self.assertFalse(out_dir.exists())
+            writer.write(ragpack, out_dir)
+            self.assertTrue(out_dir.is_dir())
+
+    def test_existing_file_at_output_dir_raises_value_error(self):
+        ragpack = _build_ragpack()
+        writer  = RagpackWriter()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            conflict = Path(tmp) / "file_not_dir"
+            conflict.write_text("oops")
+            with self.assertRaises(ValueError):
+                writer.write(ragpack, conflict)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Title
<!-- e.g., "feat(pipeline): RAGpack v1.1 (manifest + paragraph offsets + validator)" -->

## What & Why
- **What**: <!-- Short description of modules touched: chunker / embedder / indexer / writer / schemas / cli / notebooks -->
- **Why**: <!-- DeepSearch support / quality / performance / compatibility -->

## Scope
- [ ] chunker  (token/sentence, offsets)
- [ ] embedder (model meta: name/version/hash/dim)
- [ ] indexer  (doc_id/title/path/page/line/timestamp, bm25)
- [ ] writer   (pack.manifest.json, chunks.json, citations.jsonl, metadata.json, embeddings.npy/csv)
- [ ] schemas  (pack.manifest.v1_1, citations.jsonl line)
- [ ] cli      (`nn-pack build|validate|show-manifest`)
- [ ] notebook (build_ragpack.ipynb)
- [ ] docs     (README, examples)
- [ ] tests    (unit/integration/perf)

## Linked Issue
Closes #<ISSUE_NUMBER>

## How to Test
### Build a sample pack
```bash
nn-pack build \
  --input ./corpus \
  --output ./exported/my_pack_v1_1 \
  --chunk-size 512 --chunk-overlap 50 \
  --embedder e5-small-gguf --para-offsets char --bm25-stats on

Validate

nn-pack validate ./exported/my_pack_v1_1
# expect exit 0 and a readable summary (pack_version=1.1, counts, warnings=0)

Acceptance (DoD)
	•	pack.manifest.json (v1.1 fields present)
	•	citations.jsonl has {para_id,start,end,snippet} (≥95% coverage)
	•	validate exits 0 for good pack, non‑zero with clear errors for bad pack
	•	notebooks/build_ragpack.ipynb produces v1.1 end‑to‑end
	•	Backward compat: v1.0 warns “Limited citations” (no crash)
	•	Performance within baseline ±10%

Artifacts
	•	Attach or link a tiny toy pack under exported/ for reviewers
	•	Paste validator summary here

Risks / Migration
	•	Breaking?  No / Yes (describe)
	•	Migration notes: 

Checklist
	•	Conversations resolved
	•	CI green (validator runs on sample pack)
	•	No merge commits (Squash)
	•	Signed or Squash‑verified commit
	•	Code comments in English
	•	Docs updated (README + examples)