### PR TITLE
feat(notebook): interactive RAGpack v1.2 builder (Colab + Jupyter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ Usage:
 
 ---
 
+### Interactive notebook (Colab or local Jupyter)
+
+For an interactive build flow with step-by-step verification, see
+`notebooks/build_ragpack_v1_2.ipynb`. Open it directly in Colab via:
+
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rag-fish/noesisnoema-pipeline/blob/main/notebooks/build_ragpack_v1_2.ipynb)
+
+The notebook wraps `cli.build_ragpack.run_pipeline_v12()` with cells for
+dependency install, GGUF fingerprint verification, source upload, and zip
+download. It produces the same v1.2 RAGpack as the CLI.
+
+---
+
 ## Troubleshooting
 - **403 Forbidden (gated)**: Accept the license on the model page and ensure your token allows **Gated repos: Read**.
 - **Nothing downloads / 404**: Double‑check `repo_id` and make sure the repo actually contains `.gguf` files.

--- a/notebooks/build_ragpack_v1_2.ipynb
+++ b/notebooks/build_ragpack_v1_2.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# RAGpack v1.2 builder for NoesisNoema (ADR-0011 §5).\n\nThis notebook is the **interactive companion** to the CLI\n`nn-pipeline build`. It wraps the same `cli.build_ragpack.run_pipeline_v12()`\nfunction the CLI calls — it adds **no** pipeline logic, only a notebook UX\nwith step-by-step verification. The CLI remains the canonical entry point.\n\n**What it does:** installs the pipeline, takes an embedder GGUF and your\n`.txt`/`.md` source documents, builds a v1.2 RAGpack, and zips it for\ndownload or Drive save — displaying each artifact as it lands.\n\n**Output:** a v1.2 RAGpack (`manifest.json`, `embeddings.npy`, `chunks.json`,\n`citations.jsonl`) consumed by the **NoesisNoema v0.4+** app\n(Settings ▸ Manage RAGpacks ▸ Import .zip).\n\n**Reference:** ADR-0011 in [`rag-fish/RAGfish`](https://github.com/rag-fish/RAGfish).\n\n> **Important:** the embedder GGUF must be `nomic-embed-text-v1.5.Q5_K_M.gguf`\n> (or a fingerprint-matching variant) to be importable by the current app\n> build. The fingerprint is verified in Cell 5.\n\nRuns on **Colab** (primary target, CPU is sufficient) or **local Jupyter /\nVS Code** — Drive mounting and Colab upload are guarded by `try/except`."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import sys\n\nIS_COLAB = \"google.colab\" in sys.modules\nprint(f\"Environment: {'Colab' if IS_COLAB else 'Local Jupyter'}\")\nprint(f\"Python: {sys.version.split()[0]}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Install dependencies\n\nIn **Colab** both lines below run (they are Colab-only). The pipeline already\npins `llama-cpp-python>=0.3.0` in its `pyproject.toml`, so the second install\nis an idempotent no-op kept explicit for clarity. In **local** mode nothing is\ninstalled — `pip install -e .` from the repo root is assumed done already."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# Colab-only: install the pipeline from GitHub (main branch) + llama-cpp-python.\n# Locally: assume the pipeline is already installed in the active env.\nif IS_COLAB:\n    !pip install -q git+https://github.com/rag-fish/noesisnoema-pipeline.git@main  # Colab-only\n    !pip install -q llama-cpp-python  # Colab-only; idempotent (already a pipeline dep)\nelse:\n    print(\"Local mode — using the installed pipeline package \"\n          \"(pip install -e . from the repo root).\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Obtain the embedder GGUF\n\nThree ways to point at the GGUF, handled by the single cell below:\n\n- **Option A (Colab, recommended for repeat runs):** mount Google Drive and\n  read the GGUF from a Drive path.\n- **Option B (Colab, one-shot):** if the Drive path is missing, upload the\n  GGUF directly via the file chooser.\n- **Option C (local):** set `GGUF_PATH` to a local filesystem path."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import os\nfrom pathlib import Path\n\nif IS_COLAB:\n    # OPTION A: mount Drive (recommended for repeat runs)\n    try:\n        from google.colab import drive\n        drive.mount(\"/content/drive\")\n        # Adjust the path below to wherever you keep the GGUF in your Drive:\n        GGUF_PATH = Path(\"/content/drive/MyDrive/Models/nomic-embed-text-v1.5.Q5_K_M.gguf\")\n    except Exception:\n        GGUF_PATH = None\n    # OPTION B: direct upload (one-shot)\n    if GGUF_PATH is None or not GGUF_PATH.is_file():\n        from google.colab import files\n        print(\"Drive path not found — please upload the GGUF directly:\")\n        uploaded = files.upload()  # opens a chooser; user picks the GGUF\n        GGUF_PATH = Path(\"/content\") / next(iter(uploaded.keys()))\nelse:\n    # OPTION C: local path — adjust as needed\n    GGUF_PATH = Path(\"/path/to/nomic-embed-text-v1.5.Q5_K_M.gguf\")\n\nassert GGUF_PATH.is_file(), f\"GGUF not found at {GGUF_PATH}\"\nprint(f\"GGUF: {GGUF_PATH}  ({GGUF_PATH.stat().st_size / 1024**2:.1f} MB)\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Verify the GGUF SHA-256 fingerprint\n\nCritical identity check (ADR-0011 §3). The app validates `embedder.model_hash`\non import, and that hash is the SHA-256 of the GGUF file. This cell **does not\nhalt on mismatch** — you may be deliberately building for a future/experimental\nembedder — it just prints the result clearly."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import hashlib\n\nEXPECTED_FINGERPRINT = \"0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6\"\n\ndef sha256_file(path: Path) -> str:\n    h = hashlib.sha256()\n    with open(path, \"rb\") as f:\n        for chunk in iter(lambda: f.read(1024 * 1024), b\"\"):\n            h.update(chunk)\n    return h.hexdigest()\n\nactual = sha256_file(GGUF_PATH)\nprint(f\"SHA-256:  {actual}\")\nprint(f\"Expected: {EXPECTED_FINGERPRINT}\")\nif actual == EXPECTED_FINGERPRINT:\n    print(\"✅ Fingerprint matches the NoesisNoema app embedder.\")\nelse:\n    print(\"⚠️  Fingerprint does NOT match. The resulting pack will be rejected \"\n          \"by NoesisNoema v0.4+ unless the app is rebuilt with this GGUF.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Source documents (.txt / .md only)\n\nThe pipeline ingests `.txt` and `.md` files only. PDF is **not** handled\ndirectly — if you have PDFs, run the optional conversion cell below first,\nthen re-run this cell."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "INPUT_DIR = Path(\"/content/input\") if IS_COLAB else Path(\"./input\")\nINPUT_DIR.mkdir(exist_ok=True)\n\nif IS_COLAB:\n    # Direct upload — user selects .txt/.md files.\n    from google.colab import files\n    print(\"Upload one or more .txt or .md files (PDF not directly supported; \"\n          \"convert PDF → txt first if needed).\")\n    uploaded = files.upload()\n    for name, data in uploaded.items():\n        (INPUT_DIR / name).write_bytes(data)\nelse:\n    print(f\"Local mode — place .txt/.md files in {INPUT_DIR.resolve()} and \"\n          \"re-run this cell to list them.\")\n\nsource_files = sorted(p for p in INPUT_DIR.iterdir()\n                      if p.is_file() and p.suffix.lower() in {\".txt\", \".md\"})\nprint(f\"\\nSource files ({len(source_files)}):\")\nfor p in source_files:\n    print(f\"  {p.name}  ({p.stat().st_size / 1024:.1f} KB)\")\n\nassert source_files, f\"No .txt or .md files in {INPUT_DIR}\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## (Optional) PDF → txt pre-conversion\n\nIf you have `.pdf` files, run this cell to convert them to `.txt` next to the\noriginals; otherwise **skip it**. Uses `pypdf` (lightweight, pure-Python).\nAfter running, **re-run Cell 6** to pick up the new `.txt` files."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "# OPTIONAL: convert any .pdf files in INPUT_DIR to .txt next to them.\n# Uses pypdf (lightweight, pure-Python). Adjust as needed.\ndef convert_pdfs_to_txt(directory: Path) -> int:\n    try:\n        from pypdf import PdfReader\n    except ImportError:\n        !pip install -q pypdf\n        from pypdf import PdfReader\n    pdfs = list(directory.glob(\"*.pdf\"))\n    for pdf_path in pdfs:\n        reader = PdfReader(str(pdf_path))\n        text = \"\\n\\n\".join((page.extract_text() or \"\") for page in reader.pages)\n        out_path = pdf_path.with_suffix(\".txt\")\n        out_path.write_text(text, encoding=\"utf-8\")\n        print(f\"  {pdf_path.name} → {out_path.name}  ({len(text):,} chars)\")\n    return len(pdfs)\n\nn = convert_pdfs_to_txt(INPUT_DIR)\nprint(f\"Converted {n} PDF(s). Re-run Cell 6 to list the new .txt files.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Configuration\n\n**Note on reproducibility:** `creation_time` feeds the deterministic `pack_id`\nderivation (`_derive_pack_id` in `cli/build_ragpack.py`). Using `datetime.now()`\nbelow means the `pack_id` changes on every run. To get a **reproducible** pack\n(same sources + embedder + config + time → same `pack_id`), pin `CREATION_TIME`\nto a fixed string instead, e.g. `CREATION_TIME = \"2026-06-10T00:00:00Z\"`."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from datetime import datetime, timezone\n\nOUTPUT_DIR = Path(\"/content/output\") if IS_COLAB else Path(\"./output\")\nOUTPUT_DIR.mkdir(exist_ok=True)\n\nCHUNK_SIZE    = 512    # tokens per chunk\nOVERLAP       = 50     # token overlap between chunks\nCREATION_TIME = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(\"+00:00\", \"Z\")\n\nprint(f\"chunk_size:    {CHUNK_SIZE}\")\nprint(f\"overlap:       {OVERLAP}\")\nprint(f\"creation_time: {CREATION_TIME}\")\nprint(f\"output_dir:    {OUTPUT_DIR}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Build the pack\n\nCalls the canonical `run_pipeline_v12()` — the exact function the CLI invokes\nfor `--embedder llama-cpp`. The first call loads the GGUF (a few seconds on CPU)."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from cli.build_ragpack import run_pipeline_v12\n\nresult = run_pipeline_v12(\n    input_dir=INPUT_DIR,\n    output_dir=OUTPUT_DIR,\n    gguf_path=GGUF_PATH,\n    chunk_size=CHUNK_SIZE,\n    overlap=OVERLAP,\n    creation_time=CREATION_TIME,\n    verbose=True,\n)\n\nprint(f\"\\n✅ Build complete.\")\nprint(f\"   files:  {result.file_count}\")\nprint(f\"   chunks: {result.chunk_count}\")\nprint(f\"   output: {result.output_dir}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Inspect the manifest\n\nVisually verify the manifest is well-formed for the app:\n\n- `pack_version == \"1.2\"`\n- `embedder.model_hash` matches the expected fingerprint (Cell 5)\n- `embedder.embedding_dimension == 768`\n- `embedder.pooling == \"mean\"`\n- `embedder.l2_normalized == true`"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import json\n\nwith open(result.written_paths[\"manifest\"]) as f:\n    manifest = json.load(f)\n\nprint(json.dumps(manifest, indent=2, ensure_ascii=False))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Inspect embeddings shape\n\nVerify shape is `(N, 768)`, dtype `float32`, and the first-row norm ≈ 1.0\n(rows are L2-normalized)."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import numpy as np\n\narr = np.load(result.written_paths[\"embeddings\"])\nprint(f\"embeddings.npy shape: {arr.shape}\")\nprint(f\"dtype:                {arr.dtype}\")\nprint(f\"first row norm:       {np.linalg.norm(arr[0]):.6f}\")\nprint(f\"first 8 values:       {arr[0, :8]}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Inspect chunks + citations\n\n`chunks.json` holds the chunk text and metadata; `citations.jsonl` holds one\ncitation record per line. `chunk_index` aligns with the `embeddings.npy` row."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "with open(result.written_paths[\"chunks\"]) as f:\n    chunks = json.load(f)\n\nprint(f\"Total chunks: {len(chunks)}\\n\")\nprint(\"First chunk:\")\nprint(json.dumps(chunks[0], indent=2, ensure_ascii=False)[:500])\nprint(\"…\")\n\n# Citations\nprint(\"\\nFirst 3 citations:\")\nwith open(result.written_paths[\"citations\"]) as f:\n    for i, line in enumerate(f):\n        if i >= 3:\n            break\n        print(json.dumps(json.loads(line), indent=2, ensure_ascii=False)[:300])\n        print(\"---\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Zip + offer download\n\nArchives the output directory into a single `.zip`. In Colab the browser\ndownload is triggered automatically; locally the path is printed."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import shutil\n\nzip_base = OUTPUT_DIR.parent / OUTPUT_DIR.name\nzip_path = Path(shutil.make_archive(str(zip_base), \"zip\", str(OUTPUT_DIR)))\nprint(f\"✅ Zipped: {zip_path}  ({zip_path.stat().st_size / 1024**2:.2f} MB)\")\n\nif IS_COLAB:\n    from google.colab import files\n    files.download(str(zip_path))  # triggers browser download\n    print(\"Downloading…\")\nelse:\n    print(f\"Local mode — zip available at {zip_path.resolve()}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## (Optional) Save to Drive\n\nIn Colab, copies the zip into `MyDrive/Ragpacks` for safekeeping. Skipped locally."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "if IS_COLAB:\n    drive_out = Path(\"/content/drive/MyDrive/Ragpacks\")\n    drive_out.mkdir(parents=True, exist_ok=True)\n    shutil.copy(zip_path, drive_out / zip_path.name)\n    print(f\"✅ Saved to Drive: {drive_out / zip_path.name}\")\nelse:\n    print(\"Local mode — Drive save skipped.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Next steps & troubleshooting\n\n**Import into NoesisNoema:** Settings ▸ Manage RAGpacks ▸ Import .zip, then\nselect the downloaded `output.zip`.\n\n**If the app rejects the pack**, the alert names the exact validation that\nfailed — adjust the GGUF or rebuild the app accordingly:\n\n- `embedderFingerprintMismatch` — the GGUF SHA-256 ≠ the app's expected hash\n  (see Cell 5). Use the matching GGUF, or rebuild the app with this GGUF.\n- `embeddingDimensionMismatch` — embeddings aren't `(N, 768)`; wrong embedder.\n- Other validations map 1:1 to the manifest fields checked in Cell 9.\n\n**Verify retrieval quality:** run the 5-question RAG verification UAT recorded\nin ADR-0011 / past transcripts against the imported pack."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "colab": {
+   "provenance": []
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds an **interactive Colab/Jupyter notebook** companion to the CLI
`nn-pipeline build`. It is a **thin wrapper** around
`cli.build_ragpack.run_pipeline_v12()` — the exact function the CLI invokes for
`--embedder llama-cpp`. **No pipeline logic changes**: no embedder/chunker/
writer/manifest/schema/CLI edits, no new `pyproject.toml`/`requirements.txt`
dependencies.

- Context: ADR-0011 §5 (`rag-fish/RAGfish`) — Taka's preferred interactive,
  visually-verifiable RAGpack generation workflow.
- Builds on **PR #13** (v1.2 llama.cpp embedder + nested manifest).

## ⚠️ Base branch note (please read)

The task brief assumed PR #13 was already merged to `main` (so
`run_pipeline_v12` would be importable from `main`). In this repo it is **not**:
local `main` is still at `28e62f6 EPIC3 …(#12)`, and all v1.2 code lives on
`feat/ragpack-v12-llamacpp-embedder` (PR #13, open). I therefore **based this PR
on `feat/ragpack-v12-llamacpp-embedder`** instead of `main`, so the diff is just
the 2 notebook/README commits rather than conflating PR #13's 5 commits. Once
#13 merges to `main`, retarget this PR's base to `main` (the Colab badge URL
already points at `…/blob/main/notebooks/…`, which resolves after that merge).

## Cell-by-cell summary

1. **Intro (md)** — what the notebook is, output, consumer (NoesisNoema v0.4+), ADR-0011 link, GGUF requirement.
2. **Env detection** — `IS_COLAB = "google.colab" in sys.modules`; prints Python version.
3. **Install deps** — Colab-only `pip install git+…@main` + `llama-cpp-python` (idempotent; already a pipeline dep). Local mode is a no-op.
4. **Obtain GGUF** — Option A: mount Drive; Option B: Colab `files.upload()` fallback; Option C: local path. Asserts the file exists.
5. **Verify fingerprint** — SHA-256 of the GGUF vs the expected app hash; prints ✅/⚠️ but **never halts** on mismatch.
6. **Source docs** — `.txt`/`.md` only; Colab upload or local dir; lists and asserts non-empty.
6.5. **(Optional) PDF→txt** — `pypdf`-based pre-conversion; re-run Cell 6 after.
7. **Config** — `chunk_size=512`, `overlap=50`, `creation_time` (with a markdown note that `datetime.now()` changes `pack_id` per run; pin for reproducibility).
8. **Build** — calls `run_pipeline_v12(...)`, prints file/chunk counts + output dir.
9. **Inspect manifest** — pretty-prints `manifest.json`; commentary on `pack_version=="1.2"`, `embedder.model_hash`, `embedding_dimension==768`, `pooling=="mean"`, `l2_normalized==true`.
10. **Inspect embeddings** — `np.load`; verifies `(N, 768)` float32, first-row norm ≈ 1.0.
11. **Inspect chunks + citations** — first chunk + first 3 citation records.
12. **Zip + download** — `shutil.make_archive`; Colab `files.download`, else prints path.
13. **(Optional) Save to Drive** — copies the zip to `MyDrive/Ragpacks` in Colab.
14. **Footer (md)** — import path (Settings ▸ Manage RAGpacks ▸ Import .zip), troubleshooting (`embedderFingerprintMismatch` / `embeddingDimensionMismatch`), pointer to the 5-question RAG UAT.

## README badge added

```
https://colab.research.google.com/github/rag-fish/noesisnoema-pipeline/blob/main/notebooks/build_ragpack_v1_2.ipynb
```

## Verification

- Notebook is valid JSON; 27 cells (14 markdown, 13 code); nbformat 4.4. (`nbformat_minor=4` chosen so cells need no `id` field — strictly valid without synthesizing ids.)
- `from cli.build_ragpack import run_pipeline_v12` imports cleanly in the v12 venv.
- Notebook calls **only** `run_pipeline_v12` (not the legacy v1.1 `run_pipeline`).
- Fingerprint cell uses the same expected hash as the app side: `0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6`.

## Scope decisions

- **`.gitignore` unchanged** — `.ipynb_checkpoints/` is already ignored (lines 317 & 402), so the N3 commit was unnecessary.
- **No smoke test added** — `nbformat`/`nbclient` aren't pipeline deps; adding the optional `tests/notebooks/` parse test would either require a new dep or fail to collect. Skipped per the brief's "skip if not already deps."

## Orthogonal findings

- PR #13 is **not merged to `main`** (see base note above).
- `.venv-v12/` in the repo root is **untracked and not gitignored** — likely should be added to `.gitignore` (left out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Do **not** merge — Taka tests the notebook in Colab against the real Spinoza Ethica PDF and merges if it produces an importable pack.