### PR TITLE
fix(notebook): guard downstream cells against missing build result

### DIFF
--- a/notebooks/build_ragpack_v1_2.ipynb
+++ b/notebooks/build_ragpack_v1_2.ipynb
@@ -63,7 +63,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## (Optional) PDF → txt pre-conversion\n\nIf you have `.pdf` files, run this cell to convert them to `.txt` next to the\noriginals; otherwise **skip it**. Uses `pypdf` (lightweight, pure-Python).\nAfter running, **re-run Cell 6** to pick up the new `.txt` files."
+   "source": "## (Optional) PDF → txt pre-conversion\n\nIf you have `.pdf` files, run this cell to convert them to `.txt` next to the\noriginals; with no PDFs present it **skips quietly**. Uses `pypdf`\n(lightweight, pure-Python). Converted `.txt` files are picked up\nautomatically and re-listed below — no need to re-run the upload cell."
   },
   {
    "cell_type": "code",
@@ -87,7 +87,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Build the pack\n\nCalls the canonical `run_pipeline_v12()` — the exact function the CLI invokes\nfor `--embedder llama-cpp`. The first call loads the GGUF (a few seconds on CPU)."
+   "source": "## Build the pack\n\nCalls the canonical `run_pipeline_v12()` — the exact function the CLI invokes\nfor `--embedder llama-cpp`. The first call loads the GGUF (a few seconds on CPU).\nIf this cell prints a warning instead of building, fix the inputs and re-run —\nthe inspect/zip cells below all depend on a successful build."
   },
   {
    "cell_type": "code",
@@ -106,7 +106,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "import json\n\nwith open(result.written_paths[\"manifest\"]) as f:\n    manifest = json.load(f)\n\nprint(json.dumps(manifest, indent=2, ensure_ascii=False))"
+   "source": "import json\n\nif \"result\" not in globals():\n    print(\"No build result yet — run the Build cell successfully first.\")\nelse:\n    with open(result.written_paths[\"manifest\"]) as f:\n        manifest = json.load(f)\n\n    print(json.dumps(manifest, indent=2, ensure_ascii=False))"
   },
   {
    "cell_type": "markdown",
@@ -118,7 +118,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "import numpy as np\n\narr = np.load(result.written_paths[\"embeddings\"])\nprint(f\"embeddings.npy shape: {arr.shape}\")\nprint(f\"dtype:                {arr.dtype}\")\nprint(f\"first row norm:       {np.linalg.norm(arr[0]):.6f}\")\nprint(f\"first 8 values:       {arr[0, :8]}\")"
+   "source": "import numpy as np\n\nif \"result\" not in globals():\n    print(\"No build result yet — run the Build cell successfully first.\")\nelse:\n    arr = np.load(result.written_paths[\"embeddings\"])\n    print(f\"embeddings.npy shape: {arr.shape}\")\n    print(f\"dtype:                {arr.dtype}\")\n    print(f\"first row norm:       {np.linalg.norm(arr[0]):.6f}\")\n    print(f\"first 8 values:       {arr[0, :8]}\")"
   },
   {
    "cell_type": "markdown",
@@ -130,7 +130,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "with open(result.written_paths[\"chunks\"]) as f:\n    chunks = json.load(f)\n\nprint(f\"Total chunks: {len(chunks)}\\n\")\nprint(\"First chunk:\")\nprint(json.dumps(chunks[0], indent=2, ensure_ascii=False)[:500])\nprint(\"…\")\n\n# Citations\nprint(\"\\nFirst 3 citations:\")\nwith open(result.written_paths[\"citations\"]) as f:\n    for i, line in enumerate(f):\n        if i >= 3:\n            break\n        print(json.dumps(json.loads(line), indent=2, ensure_ascii=False)[:300])\n        print(\"---\")"
+   "source": "if \"result\" not in globals():\n    print(\"No build result yet — run the Build cell successfully first.\")\nelse:\n    with open(result.written_paths[\"chunks\"]) as f:\n        chunks = json.load(f)\n\n    print(f\"Total chunks: {len(chunks)}\\n\")\n    print(\"First chunk:\")\n    print(json.dumps(chunks[0], indent=2, ensure_ascii=False)[:500])\n    print(\"…\")\n\n    # Citations\n    print(\"\\nFirst 3 citations:\")\n    with open(result.written_paths[\"citations\"]) as f:\n        for i, line in enumerate(f):\n            if i >= 3:\n                break\n            print(json.dumps(json.loads(line), indent=2, ensure_ascii=False)[:300])\n            print(\"---\")"
   },
   {
    "cell_type": "markdown",
@@ -142,7 +142,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "import shutil\n\nzip_base = OUTPUT_DIR.parent / OUTPUT_DIR.name\nzip_path = Path(shutil.make_archive(str(zip_base), \"zip\", str(OUTPUT_DIR)))\nprint(f\"✅ Zipped: {zip_path}  ({zip_path.stat().st_size / 1024**2:.2f} MB)\")\n\nif IS_COLAB:\n    from google.colab import files\n    files.download(str(zip_path))  # triggers browser download\n    print(\"Downloading…\")\nelse:\n    print(f\"Local mode — zip available at {zip_path.resolve()}\")"
+   "source": "import shutil\n\nif \"result\" not in globals():\n    print(\"No build result yet — run the Build cell successfully first.\")\nelse:\n    zip_base = OUTPUT_DIR.parent / OUTPUT_DIR.name\n    zip_path = Path(shutil.make_archive(str(zip_base), \"zip\", str(OUTPUT_DIR)))\n    print(f\"✅ Zipped: {zip_path}  ({zip_path.stat().st_size / 1024**2:.2f} MB)\")\n\n    if IS_COLAB:\n        from google.colab import files\n        files.download(str(zip_path))  # triggers browser download\n        print(\"Downloading…\")\n    else:\n        print(f\"Local mode — zip available at {zip_path.resolve()}\")"
   },
   {
    "cell_type": "markdown",
@@ -154,7 +154,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "if IS_COLAB:\n    drive_out = Path(\"/content/drive/MyDrive/Ragpacks\")\n    drive_out.mkdir(parents=True, exist_ok=True)\n    shutil.copy(zip_path, drive_out / zip_path.name)\n    print(f\"✅ Saved to Drive: {drive_out / zip_path.name}\")\nelse:\n    print(\"Local mode — Drive save skipped.\")"
+   "source": "if \"zip_path\" not in globals():\n    print(\"No zip yet — run the Zip cell first.\")\nelif IS_COLAB:\n    drive_out = Path(\"/content/drive/MyDrive/Ragpacks\")\n    drive_out.mkdir(parents=True, exist_ok=True)\n    shutil.copy(zip_path, drive_out / zip_path.name)\n    print(f\"✅ Saved to Drive: {drive_out / zip_path.name}\")\nelse:\n    print(\"Local mode — Drive save skipped.\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Third UAT failure fix. When the Build cell's guard fires (no sources) — or after a Colab runtime restart wipes variables — `result` is never assigned, and the downstream manifest-inspect cell raised a raw `NameError`:

```
NameError: name 'result' is not defined
---> with open(result.written_paths["manifest"]) as f:
```

The first hotfix (PR #16) made the upload/build cells graceful but left the five downstream cells unguarded — half-finished graceful degradation. This PR completes it.

## Changes (1 file, `notebooks/build_ragpack_v1_2.ipynb`)

**Guarded cells** — each now prints `No build result yet — run the Build cell successfully first.` instead of a traceback when `result` is missing:
1. Inspect manifest
2. Inspect embeddings shape
3. Inspect chunks + citations
4. Zip + download
5. Save to Drive (checks `zip_path`, its actual dependency)

**Markdown touch-ups (same commit):**
- PDF-conversion cell description still said "re-run Cell 6" — stale since PR #16's code already re-lists ready sources itself. Updated.
- Build cell description now states the downstream cells depend on a successful build.

All other cells byte-identical to `main` (`8fbc1468`).

## Behavior after this fix

"Run all" with missing inputs now degrades into a readable chain: upload cell says what's missing → build cell says what to do → every downstream cell says "no build result yet". No tracebacks anywhere in the happy-cancel path.

🤖 Fix authored + committed via MCP by Claude (sandbox), commit `b18b402`.