### PR TITLE
feat(notebook): name the ragpack zip after the source document

### DIFF
--- a/notebooks/build_ragpack_v1_2.ipynb
+++ b/notebooks/build_ragpack_v1_2.ipynb
@@ -458,8 +458,9 @@
    "source": [
     "## Zip + offer download\n",
     "\n",
-    "Archives the output directory into a single `.zip`. In Colab the browser\n",
-    "download is triggered automatically; locally the path is printed."
+    "Archives the output directory into a `<source-name>_ragpack.zip` (named after the\n",
+    "first source document, sanitized). In Colab the browser download is triggered\n",
+    "automatically; locally the path is printed."
    ]
   },
   {
@@ -474,12 +475,19 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "import re\n",
     "import shutil\n",
     "\n",
     "if \"result\" not in globals():\n",
     "    print(\"No build result yet — run the Build cell successfully first.\")\n",
     "else:\n",
-    "    zip_base = OUTPUT_DIR.parent / OUTPUT_DIR.name\n",
+    "    source_files = sorted(p for p in INPUT_DIR.iterdir()\n",
+    "                          if p.is_file() and p.suffix.lower() in {\".txt\", \".md\"})\n",
+    "\n",
+    "    stem = source_files[0].stem if source_files else OUTPUT_DIR.name\n",
+    "    safe = re.sub(r\"[^A-Za-z0-9._-]\", \"_\", stem)[:40].rstrip(\"._-\") or OUTPUT_DIR.name\n",
+    "    zip_base = OUTPUT_DIR.parent / f\"{safe}_ragpack\"\n",
+    "\n",
     "    zip_path = Path(shutil.make_archive(str(zip_base), \"zip\", str(OUTPUT_DIR)))\n",
     "    print(f\"✅ Zipped: {zip_path}  ({zip_path.stat().st_size / 1024**2:.2f} MB)\")\n",
     "\n",


### PR DESCRIPTION
## Why

Taka's UX request: the Zip cell always archived to `output.zip`, which is opaque once a user accumulates multiple packs on disk — there's no way to tell which source document a `.zip` came from. This names the archive after the first source document.

## What changed

Touches **only** `notebooks/build_ragpack_v1_2.ipynb` — the Zip code cell + its preceding markdown header. Nothing else.

The Zip cell now re-derives `source_files` from `INPUT_DIR` with the same guarded glob already used in the Build/Inspect cells (so it's self-contained after a runtime restart), still gated behind the existing PR #18 `if "result" not in globals()` guard. The naming logic lives in the `else` branch:

```python
stem = source_files[0].stem if source_files else OUTPUT_DIR.name
safe = re.sub(r"[^A-Za-z0-9._-]", "_", stem)[:40].rstrip("._-") or OUTPUT_DIR.name
zip_base = OUTPUT_DIR.parent / f"{safe}_ragpack"
```

### Sanitization rules

- **Character whitelist** `[A-Za-z0-9._-]` — every other char (incl. unicode, spaces, shell-unfriendly chars) becomes `_`.
- **40-char cap** — `[:40]` guards against absurdly long titles.
- **`.rstrip("._-")`** — trims trailing punctuation so the final filename stays tidy.
- **`or OUTPUT_DIR.name` fallback** — covers the edge case where sanitization eats the whole stem (e.g. a fully non-ASCII title).

Concrete example:

```
2015.263056.Ethics_text.txt  →  2015.263056.Ethics_text_ragpack.zip
```

## Verification

**JSON validity (`python -c "import json; json.load(...)"`):**
```
valid JSON
nbformat 4.4
27 cells
```

**All other cells byte-identical:** confirmed via a per-cell comparison against `HEAD` — only cells 22 (markdown header) and 23 (Zip code) differ; top-level `metadata`, `nbformat`, and `nbformat_minor` unchanged.
```
cells that differ: [22, 23]
metadata identical: True
```

## Orthogonal findings (noted, not fixed)

- `source_files` filters to `.txt`/`.md` only, so a PDF like `2015.263056.Ethics_text.pdf` names the zip via its converted `.txt` sibling's stem — which yields the expected `2015.263056.Ethics_text_ragpack.zip`. Intentional, matches the spec example; just flagging the indirection.

Do **not** merge — Taka merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)